### PR TITLE
Scripts: wrong options handling

### DIFF
--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -357,7 +357,7 @@ export class Application {
                 featureName: targetFeature.featureName,
                 socketServer,
                 features: new Map(features),
-                options: targetFeature.options ? new Map(Object.entries(targetFeature.options)) : undefined
+                options: targetFeature.options
             });
 
             const topologyForFeature: Record<string, string> = {};


### PR DESCRIPTION
We have a wrong handing in the runNodeEnv function which causes runOptions not to pass when  the runNodeEnvironment is being called