### PR TITLE
Com: socket scoping to environment

### DIFF
--- a/packages/scripts/src/node-environments-manager.ts
+++ b/packages/scripts/src/node-environments-manager.ts
@@ -60,7 +60,7 @@ export class NodeEnvironmentsManager {
             );
             disposables.push(() => close());
 
-            topology[nodeEnv.name] = `http://localhost:${port}/_ws`;
+            topology[nodeEnv.name] = `http://localhost:${port}/${nodeEnv.name}`;
         }
 
         const runningEnvironment: IRuntimeEnvironment = {

--- a/packages/scripts/src/run-node-environment.ts
+++ b/packages/scripts/src/run-node-environment.ts
@@ -10,7 +10,7 @@ export async function runNodeEnvironment(
     { featureName, childEnvName, features, config = [], name, type, options }: ServerEnvironmentOptions
 ) {
     const disposeHandlers = new Set<() => unknown>();
-    const socketServerNamespace = socketServer.of('/_ws');
+    const socketServerNamespace = socketServer.of(name);
     const localDevHost = new WsServerHost(socketServerNamespace);
 
     await runEngineApp({


### PR DESCRIPTION
Socket connections will now be namespaced under the environment name, which will cause that messages from different environments don't get mixed up.