### PR TITLE
Communication: response with env as id in communication middleware

### DIFF
--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -16,7 +16,7 @@ import { ENGINE_CONFIG_FILE_NAME } from './build-constants';
 import {
     createConfigMiddleware,
     createLiveConfigsMiddleware,
-    createTopologyMiddleware,
+    createCommunicationMiddleware,
     ensureTopLevelConfigMiddleware,
     OverrideConfig
 } from './config-middleware';
@@ -202,7 +202,7 @@ export class Application {
 
         app.use(`/${publicConfigsRoute}`, [
             ensureTopLevelConfigMiddleware,
-            createTopologyMiddleware(nodeEnvironmentManager, publicPath),
+            createCommunicationMiddleware(nodeEnvironmentManager, publicPath),
             createLiveConfigsMiddleware(configurations, this.basePath, overrideConfigsMap),
             createConfigMiddleware(overrideConfig)
         ]);
@@ -340,7 +340,7 @@ export class Application {
         if (publicConfigsRoute) {
             app.use(`/${publicConfigsRoute}`, [
                 ensureTopLevelConfigMiddleware,
-                createTopologyMiddleware(nodeEnvironmentManager, publicPath),
+                createCommunicationMiddleware(nodeEnvironmentManager, publicPath),
                 createConfigMiddleware(config)
             ]);
         }

--- a/packages/scripts/src/config-middleware.ts
+++ b/packages/scripts/src/config-middleware.ts
@@ -66,12 +66,12 @@ export function createLiveConfigsMiddleware(
     };
 }
 
-export function createTopologyMiddleware(
+export function createCommunicationMiddleware(
     nodeEnvironmentsManager: NodeEnvironmentsManager,
     publicPath?: string
 ): express.RequestHandler {
     return (req, res, next) => {
-        const { feature } = req.query;
+        const { feature, env } = req.query;
         const requestedConfig: string | undefined = req.path.slice(1);
         res.locals.topLevelConfig = res.locals.topLevelConfig.concat([
             COM.use({
@@ -80,7 +80,8 @@ export function createTopologyMiddleware(
                         feature,
                         requestedConfig === 'undefined' ? undefined : requestedConfig
                     ),
-                    publicPath
+                    publicPath,
+                    id: env
                 }
             })
         ]);


### PR DESCRIPTION
Response with env as id in communication middleware in order to support a standalone preview (run preview content a new tab)