### PR TITLE
Add running environment name to universal feature setup

### DIFF
--- a/packages/core/src/communication.feature.ts
+++ b/packages/core/src/communication.feature.ts
@@ -58,7 +58,8 @@ export default new Feature({
     ({
         config: { host, id, topology, maxLogMessages, loggerSeverity, logToConsole, resolvedContexts, publicPath },
         loggerTransports,
-        [RUN_OPTIONS]: runOptions
+        [RUN_OPTIONS]: runOptions,
+        runningEnvironmentName
     }) => {
         // TODO: find better way to detect node runtime
         const isNode = typeof process !== 'undefined' && process.title !== 'browser';
@@ -66,7 +67,7 @@ export default new Feature({
         // worker and iframe always get `name` when initialized as Environment.
         // it can be overridden using top level config.
         // main frame might not have that configured, so we use 'main' fallback for it.
-        const comId = id || (host && host.name) || (typeof self !== 'undefined' && self.name) || 'main';
+        const comId = id || (host && host.name) || (typeof self !== 'undefined' && self.name) || runningEnvironmentName;
 
         const comOptions: ICommunicationOptions = {
             warnOnSlow: runOptions.has('warnOnSlow'),

--- a/packages/core/src/entities/feature.ts
+++ b/packages/core/src/entities/feature.ts
@@ -146,7 +146,8 @@ export class Feature<
             onDispose(fn: DisposeFunction) {
                 feature.addOnDisposeHandler(fn, envName);
             },
-            [RUN_OPTIONS]: runningEngine.runOptions
+            [RUN_OPTIONS]: runningEngine.runOptions,
+            runningEnvironmentName: envName
         };
 
         const emptyDispose = { dispose: () => undefined };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -141,7 +141,17 @@ export interface IRunOptions {
     get(key: string): string | boolean | null | undefined;
 }
 
-type SettingUpFeature<ID extends string, API extends EntityRecord, ENV extends string> = {
+type RunningEnvironmentNameForUniversal<ENV> = ENV extends '<Universal>'
+    ? {
+          /**
+           * The name of the current running environment while setting up a universal feature.
+           * This is NOT the environment instance id
+           */
+          runningEnvironmentName: string;
+      }
+    : {};
+
+export type SettingUpFeature<ID extends string, API extends EntityRecord, ENV extends string> = {
     id: ID;
     run: (fn: () => unknown) => void;
     onDispose: (fn: DisposeFunction) => void;
@@ -149,7 +159,8 @@ type SettingUpFeature<ID extends string, API extends EntityRecord, ENV extends s
 } & MapVisibleInputs<API, '<Universal>'> &
     MapVisibleInputs<API, ENV> &
     MapToProxyType<GetRemoteOutputs<API>> &
-    MapToProxyType<GetOnlyLocalUniversalOutputs<API>>;
+    MapToProxyType<GetOnlyLocalUniversalOutputs<API>> &
+    RunningEnvironmentNameForUniversal<ENV>;
 
 export type RegisteringFeature<
     API extends EntityRecord,


### PR DESCRIPTION
Add running environment name to feature setups. SettingUpFeature type expose the `runningEnvironmentName` param only to universal feature setups.