### PR TITLE
test-kit: handle tabs/windows opened by tests

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -160,7 +160,14 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
     afterEach(disposeAfterEach.dispose);
 
     const pages = new Set<puppeteer.Page>();
-    afterEach('close pages', () => Promise.all(Array.from(pages).map(page => page.close())).then(() => pages.clear()));
+    afterEach('close pages', async () => {
+        for (const page of pages) {
+            if (!page.isClosed()) {
+                await page.close();
+            }
+        }
+        pages.clear();
+    });
     afterEach('verify no page errors', () => {
         if (capturedErrors.length) {
             const errorsText = capturedErrors.join('\n');
@@ -218,14 +225,22 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
             if (defaultViewport) {
                 await page.setViewport(defaultViewport);
             }
-            pages.add(page);
-            page.on('pageerror', e => {
-                capturedErrors.push(e);
-                console.error(e);
-            });
+
+            (function handlePage(page: puppeteer.Page) {
+                pages.add(page);
+
+                page.on('pageerror', e => {
+                    capturedErrors.push(e);
+                    console.error(e);
+                });
+
+                // Emitted when the page opens a new tab or window
+                page.on('popup', handlePage);
+            })(page);
+
             const response = await page.goto(featureUrl + search, { waitUntil: 'networkidle0', ...navigationOptions });
 
-            return { page, response, browser };
+            return { page, response };
         }
     };
 }

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -226,7 +226,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                 await page.setViewport(defaultViewport);
             }
 
-            (function handlePage(page: puppeteer.Page) {
+            function trackPage(page: puppeteer.Page) {
                 pages.add(page);
 
                 page.on('pageerror', e => {
@@ -235,8 +235,10 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                 });
 
                 // Emitted when the page opens a new tab or window
-                page.on('popup', handlePage);
-            })(page);
+                page.on('popup', trackPage);
+            }
+
+            trackPage(page);
 
             const response = await page.goto(featureUrl + search, { waitUntil: 'networkidle0', ...navigationOptions });
 

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -225,7 +225,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
             });
             const response = await page.goto(featureUrl + search, { waitUntil: 'networkidle0', ...navigationOptions });
 
-            return { page, response };
+            return { page, response, browser };
         }
     };
 }

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -221,9 +221,11 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                 queryParams
             });
 
-            const page = await browser.newPage();
+            const featurePage = await browser.newPage();
+            trackPage(featurePage);
+
             if (defaultViewport) {
-                await page.setViewport(defaultViewport);
+                await featurePage.setViewport(defaultViewport);
             }
 
             function trackPage(page: puppeteer.Page) {
@@ -238,11 +240,12 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                 page.on('popup', trackPage);
             }
 
-            trackPage(page);
+            const response = await featurePage.goto(featureUrl + search, {
+                waitUntil: 'networkidle0',
+                ...navigationOptions
+            });
 
-            const response = await page.goto(featureUrl + search, { waitUntil: 'networkidle0', ...navigationOptions });
-
-            return { page, response };
+            return { page: featurePage, response };
         }
     };
 }


### PR DESCRIPTION
Subscribe to newly open tabs/windows from root page and close them after test.