### PR TITLE
refactor and export canAccessWindow function

### DIFF
--- a/packages/core/src/run-engine-app.ts
+++ b/packages/core/src/run-engine-app.ts
@@ -76,9 +76,9 @@ export function getTopWindow(win: Window): Window {
     return win;
 }
 
-function canAccessWindow(win: Window): boolean {
+export function canAccessWindow(win: Window): boolean {
     try {
-        return !!win.location.search;
+        return typeof win.location.search === 'string';
     } catch {
         return false;
     }


### PR DESCRIPTION
`canAccessWindow` is testing the access to `window`'s `location,search` property.
This change prevents returning `false` when `search` is an empty string.