### PR TITLE
Scripts: Allow providing feature locator a base directory for own features

### DIFF
--- a/packages/scripts/src/analyze-feature.ts
+++ b/packages/scripts/src/analyze-feature.ts
@@ -53,14 +53,14 @@ function scopeFilePathsToPackage(
     }, {});
 }
 
-export function loadFeaturesFromPackages(npmPackages: INpmPackage[], fs: IFileSystemSync) {
+export function loadFeaturesFromPackages(npmPackages: INpmPackage[], fs: IFileSystemSync, rootOwnFeaturesDir = '.') {
     const ownFeatureFilePaths = new Set<string>();
     const ownFeatureDirectoryPaths = new Set<string>();
 
     // pick up own feature files in provided npm packages
     for (const { directoryPath } of npmPackages) {
         for (const rootName of featureRoots) {
-            const rootPath = fs.join(directoryPath, rootName);
+            const rootPath = fs.join(directoryPath, rootOwnFeaturesDir, rootName);
             if (!fs.directoryExistsSync(rootPath)) {
                 continue;
             }


### PR DESCRIPTION
Currently loadFeaturesFromPackages searches at `['.', 'src', 'feature', 'fixtures']`, and this cannot be extended.
Added the possibility to define a root directory for feature locating meaning that if the feature I want to load is in ./my/path/to-feature.tsx, then I could provide to loadFeaturesFromPackages with `./my/path` as the base directory, and my feature will be found