### PR TITLE
infra: test on Node 14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [13, 12]
+        node-version: [14, 12]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Node 14.1.0 fixed broken puppeteer. lets see if anything else broke.
- drop Node 13.