### PR TITLE
 Test-kit: allow running environment on given fs

### DIFF
--- a/examples/file-server/feature/file-server.server.env.ts
+++ b/examples/file-server/feature/file-server.server.env.ts
@@ -12,6 +12,7 @@ FileServer.setup(server, ({ [RUN_OPTIONS]: runOptions }, {}) => {
     const optionsProjectPath = runOptions.get('projectPath');
 
     const projectPath = (typeof optionsProjectPath !== 'boolean' ? optionsProjectPath : undefined) || process.cwd();
+
     return {
         remoteFiles: new RemoteFilesAPI(projectPath),
     };

--- a/examples/file-server/package.json
+++ b/examples/file-server/package.json
@@ -3,7 +3,9 @@
   "version": "13.0.0",
   "scripts": {
     "start": "engine start",
-    "test": "mocha \"test/**/*.ix.ts?(x)\""
+    "test": "yarn test:ix && yarn test:unit",
+    "test:ix": "mocha \"test/**/*.ix.ts?(x)\"",
+    "test:unit": "mocha \"test/**/*.unit.ts\""
   },
   "dependencies": {
     "@file-services/directory": "^2.2.0",

--- a/examples/file-server/test/file-server.unit.ts
+++ b/examples/file-server/test/file-server.unit.ts
@@ -1,22 +1,23 @@
-import { runEngineEnvironment } from '@wixc3/engine-test-kit';
+import { getRunningFeature } from '@wixc3/engine-test-kit';
 import Feature, { server } from '../feature/file-server.feature';
 import { expect } from 'chai';
 import fs from '@file-services/node';
 
 describe('Processing env test', () => {
     it('reads directory', async () => {
-        const { dispose, engine } = await runEngineEnvironment({
+        const {
+            dispose,
+            runningApi: { remoteFiles },
+        } = await getRunningFeature({
             featureName: 'file-server',
             env: server,
             runtimeOptions: {
                 projectPath: __dirname,
             },
             fs,
+            feature: Feature,
         });
 
-        const {
-            api: { remoteFiles },
-        } = engine.get(Feature);
         const remoteFile = await remoteFiles.readFile(fs.basename(__filename));
         expect(remoteFile).to.eq(fs.readFileSync(__filename, 'utf8'));
 

--- a/examples/file-server/test/file-server.unit.ts
+++ b/examples/file-server/test/file-server.unit.ts
@@ -1,0 +1,25 @@
+import { runEngineEnvironment } from '@wixc3/engine-test-kit';
+import Feature, { server } from '../feature/file-server.feature';
+import { expect } from 'chai';
+import fs from '@file-services/node';
+
+describe('Processing env test', () => {
+    it('reads directory', async () => {
+        const { dispose, engine } = await runEngineEnvironment({
+            featureName: 'file-server',
+            env: server,
+            runtimeOptions: {
+                projectPath: __dirname,
+            },
+            fs,
+        });
+
+        const {
+            api: { remoteFiles },
+        } = engine.get(Feature);
+        const remoteFile = await remoteFiles.readFile(fs.basename(__filename));
+        expect(remoteFile).to.eq(fs.readFileSync(__filename, 'utf8'));
+
+        await dispose();
+    });
+});

--- a/examples/multi-env/package.json
+++ b/examples/multi-env/package.json
@@ -3,7 +3,9 @@
   "version": "13.0.0",
   "scripts": {
     "start": "engine start",
-    "test": "mocha \"test/**/*.ix.ts?(x)\""
+    "test": "yarn test:ix && yarn test:unit",
+    "test:ix": "mocha \"test/**/*.ix.ts?(x)\"",
+    "test:unit": "mocha \"test/**/*.unit.ts\""
   },
   "license": "UNLICENSED",
   "private": true

--- a/examples/multi-env/test/file-server.unit.ts
+++ b/examples/multi-env/test/file-server.unit.ts
@@ -1,0 +1,25 @@
+import { runEngineEnvironment } from '@wixc3/engine-test-kit';
+import Feature, { processingEnv } from '../feature/multi-env.feature';
+import { expect } from 'chai';
+import fs from '@file-services/node';
+
+describe('Processing env test', () => {
+    it('echos from node env', async () => {
+        const { dispose, engine } = await runEngineEnvironment({
+            featureName: 'multi-env/test-node',
+            env: processingEnv,
+            runtimeOptions: {
+                projectPath: __dirname,
+            },
+            fs,
+        });
+
+        const {
+            api: { echoService },
+        } = engine.get(Feature);
+        const message = await echoService.echo('text');
+        expect(message).to.eq('node env says text');
+
+        await dispose();
+    });
+});

--- a/examples/multi-env/test/file-server.unit.ts
+++ b/examples/multi-env/test/file-server.unit.ts
@@ -1,23 +1,21 @@
-import { runEngineEnvironment } from '@wixc3/engine-test-kit';
+import { getRunningFeature } from '@wixc3/engine-test-kit';
 import Feature, { processingEnv } from '../feature/multi-env.feature';
 import { expect } from 'chai';
 import fs from '@file-services/node';
 
 describe('Processing env test', () => {
     it('echos from node env', async () => {
-        const { dispose, engine } = await runEngineEnvironment({
+        const { dispose, runningApi } = await getRunningFeature({
             featureName: 'multi-env/test-node',
             env: processingEnv,
             runtimeOptions: {
                 projectPath: __dirname,
             },
             fs,
+            feature: Feature,
         });
 
-        const {
-            api: { echoService },
-        } = engine.get(Feature);
-        const message = await echoService.echo('text');
+        const message = await runningApi.echoService.echo('text');
         expect(message).to.eq('node env says text');
 
         await dispose();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@file-services/memory": "^2.2.0",
+    "@file-services/types": "^2.2.0",
     "@stylable/cli": "^3.4.5",
     "@stylable/core": "^3.4.5",
     "@stylable/webpack-plugin": "^3.4.6",

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -8,3 +8,4 @@ export * from './utils';
 export * from './node-environment';
 export * from './ws-environment';
 export * from './ipc-environment';
+export * from './load-node-environment';

--- a/packages/scripts/src/ipc-environment.ts
+++ b/packages/scripts/src/ipc-environment.ts
@@ -7,11 +7,11 @@ export async function runIPCEnvironment(options: StartEnvironmentOptions) {
     const disposeHandlers = new Set<() => unknown>();
     const host = new IPCHost(process);
     disposeHandlers.add(() => host.dispose());
-    const { close } = await runNodeEnvironment({
+    const { dispose } = await runNodeEnvironment({
         ...options,
         host,
     });
-    disposeHandlers.add(() => close());
+    disposeHandlers.add(() => dispose());
     return {
         close: async () => {
             for (const disposeHandler of disposeHandlers) {

--- a/packages/scripts/src/load-node-environment.ts
+++ b/packages/scripts/src/load-node-environment.ts
@@ -1,0 +1,29 @@
+import { resolvePackages, loadFeaturesFromPackages, IConfigDefinition } from '@wixc3/engine-scripts';
+import { IFileSystem } from '@file-services/types';
+import { SetMultiMap, TopLevelConfig } from '@wixc3/engine-core';
+
+export async function readFeatures(fs: IFileSystem, basePath: string, featuresDirectory?: string) {
+    const packages = resolvePackages(basePath);
+
+    return loadFeaturesFromPackages(packages, fs, featuresDirectory);
+}
+
+export function evaluateConfig(
+    configName: string,
+    configurations: SetMultiMap<string, IConfigDefinition>,
+    envName: string
+) {
+    const config: TopLevelConfig = [];
+    const configs = configurations.get(configName);
+    if (!configs) {
+        throw new Error(`no such config ${configName}`);
+    }
+
+    for (const { filePath, envName: configEnvName } of configs) {
+        if (!configEnvName || configEnvName === envName) {
+            config.push(...require(filePath).default);
+        }
+    }
+
+    return config;
+}

--- a/packages/scripts/src/node-environment.ts
+++ b/packages/scripts/src/node-environment.ts
@@ -22,9 +22,8 @@ export async function runNodeEnvironment({
             })
         );
     }
-    const disposeHandlers = new Set<() => unknown>();
 
-    const runningEngine = await runEngineApp({
+    return runEngineApp({
         featureName,
         featureLoaders: createFeatureLoaders(new Map(features), {
             name,
@@ -35,15 +34,6 @@ export async function runNodeEnvironment({
         options: new Map(options),
         envName: name,
     });
-    disposeHandlers.add(() => runningEngine.dispose());
-
-    return {
-        close: async () => {
-            for (const disposeHandler of disposeHandlers) {
-                await disposeHandler();
-            }
-        },
-    };
 }
 
 function createFeatureLoaders(

--- a/packages/scripts/src/node-environment.ts
+++ b/packages/scripts/src/node-environment.ts
@@ -36,7 +36,7 @@ export async function runNodeEnvironment({
     });
 }
 
-function createFeatureLoaders(
+export function createFeatureLoaders(
     features: Map<string, IFeatureDefinition>,
     { name: envName, childEnvName }: IEnvironment
 ) {

--- a/packages/scripts/src/ws-environment.ts
+++ b/packages/scripts/src/ws-environment.ts
@@ -12,8 +12,8 @@ export async function runWSEnvironment(socketServer: Server, startEnvironmentOpt
     const host = new WsServerHost(socketServerNamespace);
     disposeHandlers.add(() => host.dispose());
 
-    const { close } = await runNodeEnvironment({ ...startEnvironmentOptions, host });
-    disposeHandlers.add(() => close());
+    const { dispose } = await runNodeEnvironment({ ...startEnvironmentOptions, host });
+    disposeHandlers.add(() => dispose());
     return {
         close: async () => {
             for (const disposeHandler of [...disposeHandlers].reverse()) {

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -14,6 +14,7 @@
     "typescript": ">=3.0.0"
   },
   "dependencies": {
+    "@file-services/node": "^2.2.0",
     "@wixc3/engine-scripts": "^13.0.2",
     "is-ci": "^2.0.0",
     "promise-assist": "^1.3.0",

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -14,7 +14,6 @@
     "typescript": ">=3.0.0"
   },
   "dependencies": {
-    "@file-services/node": "^2.2.0",
     "@wixc3/engine-scripts": "^13.0.2",
     "is-ci": "^2.0.0",
     "promise-assist": "^1.3.0",

--- a/packages/test-kit/src/index.ts
+++ b/packages/test-kit/src/index.ts
@@ -2,3 +2,4 @@ export * from './create-browser-provider';
 export * from './attached-app';
 export * from './detached-app';
 export * from './with-feature';
+export * from './run-environment';

--- a/packages/test-kit/src/run-environment.ts
+++ b/packages/test-kit/src/run-environment.ts
@@ -1,0 +1,44 @@
+import { TopLevelConfig, Environment } from '@wixc3/engine-core';
+import { readFeatures, evaluateConfig, runNodeEnvironment as launch } from '@wixc3/engine-scripts';
+import { IFileSystem } from '@file-services/types';
+
+interface IRuntimeEnvironment extends Environment {
+    childEnvName?: string;
+}
+
+export interface IRunNodeEnvironmentOptions {
+    featureName: string;
+    configName?: string;
+    runtimeOptions?: Record<string, string | boolean>;
+    config?: TopLevelConfig;
+    basePath?: string;
+    env: IRuntimeEnvironment;
+    fs: IFileSystem;
+}
+
+export async function runEngineEnvironment({
+    featureName,
+    configName,
+    runtimeOptions = {},
+    config = [],
+    env,
+    basePath = process.cwd(),
+    fs,
+}: IRunNodeEnvironmentOptions) {
+    const { env: name, envType: type, childEnvName } = env;
+
+    const { features, configurations } = await readFeatures(fs, basePath);
+    if (configName) {
+        config = [...evaluateConfig(configName, configurations, name), ...config];
+    }
+
+    return launch({
+        featureName,
+        features: [...features],
+        config,
+        name,
+        type,
+        options: Object.entries(runtimeOptions),
+        childEnvName,
+    });
+}


### PR DESCRIPTION
Exposed runEnvironment method which runs an environment based on a provided fs.

Method allows passing resolved context for a contextual environment, as well as config overrides