### PR TITLE
Separate Webpack chunks for different environments

### DIFF
--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -83,7 +83,7 @@ ${Array.from(features.values())
         const envFilePath = envFilePaths[envName];
         if (envFilePath) {
             loadStatements.push(
-                `                await import(/* webpackChunkName: "${name}" */ ${stringify(envFilePath)});`
+                `                await import(/* webpackChunkName: "[${envName}]${name}" */ ${stringify(envFilePath)});`
             );
         }
 
@@ -91,7 +91,7 @@ ${Array.from(features.values())
             async load(${usesResolvedContexts ? 'resolvedContexts' : ''}) {${
             loadStatements.length ? '\n' + loadStatements.join('\n') : ''
         }
-                return (await import(/* webpackChunkName: "${name}" */ ${stringify(filePath)})).default;
+                return (await import(/* webpackChunkName: "[feature]${name}" */ ${stringify(filePath)})).default;
             },
             depFeatures: ${stringify(dependencies)},
             resolvedContexts: ${stringify(resolvedContexts)},


### PR DESCRIPTION
Currently if the feature has multiple environment files with the same target, e.g. `feature.main.env.tsx` and `feature.preview.env.tsx` with the `web` target, both are included in the same Webpack chunk. Meaning that both environments unnecessarily load all the code designated for another environment.

Even though this unused code is not evaluated, it increases parse time and memory consumption.

This PR creates one chunk for the `.feature` file, and one chunk for each `.env` file.

In the project I'm working on this separation of chunks increased the total uncompressed
amount of code in the main environment from 19.5MB to 19.9MB, and decreased the
amount of code in the preview environment from 19.0MB to 1.8MB

There's still a lot of space for improvement, for example many of the `.feature` chunks include the source code of all the features they depend on. That's roughly 1MB of duplicate code.