### PR TITLE
scripts: allow building with provided config

### DIFF
--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -53,6 +53,7 @@ export interface IRunOptions extends IFeatureTarget {
     publicConfigsRoute?: string;
     nodeEnvironmentsMode?: LaunchEnvironmentMode;
     autoLaunch?: boolean;
+    configMap?: Record<string, TopLevelConfig>;
 }
 
 export interface IBuildManifest {
@@ -94,7 +95,7 @@ export class Application {
         singleFeature,
         title,
         publicConfigsRoute,
-        overrideConfig,
+        configMap,
     }: IRunOptions = {}): Promise<webpack.compilation.MultiStats> {
         const engineConfig = await this.getEngineConfig();
         if (engineConfig && engineConfig.require) {
@@ -114,7 +115,7 @@ export class Application {
             configurations,
             staticBuild: true,
             publicConfigsRoute,
-            config: overrideConfig,
+            configMap,
         });
 
         const stats = await new Promise<webpack.compilation.MultiStats>((resolve, reject) =>
@@ -153,6 +154,7 @@ export class Application {
         publicConfigsRoute = 'configs/',
         nodeEnvironmentsMode,
         autoLaunch = true,
+        configMap,
     }: IRunOptions = {}) {
         const engineConfig = await this.getEngineConfig();
         if (engineConfig && engineConfig.require) {
@@ -179,7 +181,7 @@ export class Application {
             configurations,
             staticBuild: false,
             publicConfigsRoute,
-            config: overrideConfig,
+            configMap,
         });
 
         if (singleRun) {
@@ -218,7 +220,7 @@ export class Application {
             ensureTopLevelConfigMiddleware,
             createCommunicationMiddleware(nodeEnvironmentManager, publicPath),
             createLiveConfigsMiddleware(configurations, this.basePath, overrideConfigsMap),
-            createConfigMiddleware(),
+            createConfigMiddleware(overrideConfig),
         ]);
 
         for (const childCompiler of compiler.compilers) {
@@ -524,7 +526,7 @@ export class Application {
         configurations,
         staticBuild,
         publicConfigsRoute,
-        config,
+        configMap,
     }: {
         features: Map<string, IFeatureDefinition>;
         featureName?: string;
@@ -535,7 +537,7 @@ export class Application {
         configurations: SetMultiMap<string, IConfigDefinition>;
         staticBuild: boolean;
         publicConfigsRoute?: string;
-        config?: TopLevelConfig;
+        configMap?: Record<string, TopLevelConfig>;
     }) {
         const { basePath, outputPath } = this;
         const baseConfigPath = fs.findClosestFileSync(basePath, 'webpack.config.js');
@@ -563,7 +565,7 @@ export class Application {
             configurations,
             staticBuild,
             publicConfigsRoute,
-            config,
+            configMap,
         });
 
         const compiler = webpack(webpackConfigs);

--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -94,6 +94,7 @@ export class Application {
         singleFeature,
         title,
         publicConfigsRoute,
+        overrideConfig,
     }: IRunOptions = {}): Promise<webpack.compilation.MultiStats> {
         const engineConfig = await this.getEngineConfig();
         if (engineConfig && engineConfig.require) {
@@ -113,6 +114,7 @@ export class Application {
             configurations,
             staticBuild: true,
             publicConfigsRoute,
+            config: overrideConfig,
         });
 
         const stats = await new Promise<webpack.compilation.MultiStats>((resolve, reject) =>
@@ -177,6 +179,7 @@ export class Application {
             configurations,
             staticBuild: false,
             publicConfigsRoute,
+            config: overrideConfig,
         });
 
         if (singleRun) {
@@ -215,7 +218,7 @@ export class Application {
             ensureTopLevelConfigMiddleware,
             createCommunicationMiddleware(nodeEnvironmentManager, publicPath),
             createLiveConfigsMiddleware(configurations, this.basePath, overrideConfigsMap),
-            createConfigMiddleware(overrideConfig),
+            createConfigMiddleware(),
         ]);
 
         for (const childCompiler of compiler.compilers) {
@@ -521,6 +524,7 @@ export class Application {
         configurations,
         staticBuild,
         publicConfigsRoute,
+        config,
     }: {
         features: Map<string, IFeatureDefinition>;
         featureName?: string;
@@ -531,6 +535,7 @@ export class Application {
         configurations: SetMultiMap<string, IConfigDefinition>;
         staticBuild: boolean;
         publicConfigsRoute?: string;
+        config?: TopLevelConfig;
     }) {
         const { basePath, outputPath } = this;
         const baseConfigPath = fs.findClosestFileSync(basePath, 'webpack.config.js');
@@ -558,6 +563,7 @@ export class Application {
             configurations,
             staticBuild,
             publicConfigsRoute,
+            config,
         });
 
         const compiler = webpack(webpackConfigs);

--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -53,7 +53,10 @@ export interface IRunOptions extends IFeatureTarget {
     publicConfigsRoute?: string;
     nodeEnvironmentsMode?: LaunchEnvironmentMode;
     autoLaunch?: boolean;
-    configMap?: Record<string, TopLevelConfig>;
+    /**
+     * an object that holds per environment name, a top level config which will be injected in runtime.
+     */
+    envInjectedConfig?: Record<string, TopLevelConfig>;
 }
 
 export interface IBuildManifest {
@@ -95,7 +98,7 @@ export class Application {
         singleFeature,
         title,
         publicConfigsRoute,
-        configMap,
+        envInjectedConfig,
     }: IRunOptions = {}): Promise<webpack.compilation.MultiStats> {
         const engineConfig = await this.getEngineConfig();
         if (engineConfig && engineConfig.require) {
@@ -115,7 +118,7 @@ export class Application {
             configurations,
             staticBuild: true,
             publicConfigsRoute,
-            configMap,
+            envInjectedConfig,
         });
 
         const stats = await new Promise<webpack.compilation.MultiStats>((resolve, reject) =>
@@ -154,7 +157,7 @@ export class Application {
         publicConfigsRoute = 'configs/',
         nodeEnvironmentsMode,
         autoLaunch = true,
-        configMap,
+        envInjectedConfig,
     }: IRunOptions = {}) {
         const engineConfig = await this.getEngineConfig();
         if (engineConfig && engineConfig.require) {
@@ -181,7 +184,7 @@ export class Application {
             configurations,
             staticBuild: false,
             publicConfigsRoute,
-            configMap,
+            envInjectedConfig,
         });
 
         if (singleRun) {
@@ -526,7 +529,7 @@ export class Application {
         configurations,
         staticBuild,
         publicConfigsRoute,
-        configMap,
+        envInjectedConfig,
     }: {
         features: Map<string, IFeatureDefinition>;
         featureName?: string;
@@ -537,7 +540,7 @@ export class Application {
         configurations: SetMultiMap<string, IConfigDefinition>;
         staticBuild: boolean;
         publicConfigsRoute?: string;
-        configMap?: Record<string, TopLevelConfig>;
+        envInjectedConfig?: Record<string, TopLevelConfig>;
     }) {
         const { basePath, outputPath } = this;
         const baseConfigPath = fs.findClosestFileSync(basePath, 'webpack.config.js');
@@ -565,7 +568,7 @@ export class Application {
             configurations,
             staticBuild,
             publicConfigsRoute,
-            configMap,
+            envInjectedConfig,
         });
 
         const compiler = webpack(webpackConfigs);

--- a/packages/scripts/src/config-middleware.ts
+++ b/packages/scripts/src/config-middleware.ts
@@ -1,7 +1,7 @@
 import { COM, TopLevelConfig, SetMultiMap } from '@wixc3/engine-core';
 import type express from 'express';
 import importFresh from 'import-fresh';
-import type { IConfigDefinition } from './types';
+import type { IConfigDefinition, TopLevelConfigProvider } from './types';
 import type { NodeEnvironmentsManager } from './node-environments-manager';
 
 export interface OverrideConfig {
@@ -87,10 +87,15 @@ export function createCommunicationMiddleware(
     };
 }
 
-export const createConfigMiddleware: (overrideConfig?: TopLevelConfig) => express.RequestHandler = (
-    overrideConfig = []
-) => (_req, res) => {
-    res.send(res.locals.topLevelConfig.concat(overrideConfig));
+export const createConfigMiddleware: (
+    overrideConfig?: TopLevelConfig | TopLevelConfigProvider
+) => express.RequestHandler = (overrideConfig = []) => (req, res) => {
+    const { env: reqEnv } = req.query;
+    res.send(
+        res.locals.topLevelConfig.concat(
+            Array.isArray(overrideConfig) ? overrideConfig : reqEnv ? overrideConfig(reqEnv as string) : []
+        )
+    );
 };
 
 export const ensureTopLevelConfigMiddleware: express.RequestHandler = (_, res, next) => {

--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -16,7 +16,7 @@ export interface ICreateEntrypointsOptions {
     staticBuild: boolean;
     mode: 'production' | 'development';
     publicConfigsRoute?: string;
-    config: TopLevelConfig;
+    configMap: Record<string, TopLevelConfig>;
 }
 interface IConfigFileMapping {
     filePath: string;
@@ -60,7 +60,7 @@ export function createEntrypoint({
     mode,
     staticBuild,
     publicConfigsRoute,
-    config,
+    configMap,
 }: ICreateEntrypointsOptions) {
     const configs = getAllValidConfigurations(getConfigLoaders(configurations, mode, configName), envName);
     return `
@@ -121,7 +121,7 @@ async function main() {
     
     ${publicConfigsRoute ? fetchConfigs(publicConfigsRoute, envName) : ''}
     
-    config.push(...${JSON.stringify(config)})
+    ${configMap[envName] ? `config.push(...${JSON.stringify(configMap)})` : ``}
     
     const runtimeEngine = await runEngineApp(
         { featureName, configName, featureLoaders, config, options, envName: '${envName}', publicPath }

--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -1,6 +1,6 @@
 import { CONFIG_QUERY_PARAM, FEATURE_QUERY_PARAM } from './build-constants';
 import type { IFeatureDefinition, IConfigDefinition } from './types';
-import type { SetMultiMap } from '@wixc3/engine-core';
+import type { SetMultiMap, TopLevelConfig } from '@wixc3/engine-core';
 import { join } from 'path';
 
 const { stringify } = JSON;
@@ -16,6 +16,7 @@ export interface ICreateEntrypointsOptions {
     staticBuild: boolean;
     mode: 'production' | 'development';
     publicConfigsRoute?: string;
+    config: TopLevelConfig;
 }
 interface IConfigFileMapping {
     filePath: string;
@@ -59,6 +60,7 @@ export function createEntrypoint({
     mode,
     staticBuild,
     publicConfigsRoute,
+    config,
 }: ICreateEntrypointsOptions) {
     const configs = getAllValidConfigurations(getConfigLoaders(configurations, mode, configName), envName);
     return `
@@ -119,6 +121,7 @@ async function main() {
     
     ${publicConfigsRoute ? fetchConfigs(publicConfigsRoute, envName) : ''}
     
+    config.push(...${JSON.stringify(config)})
     
     const runtimeEngine = await runEngineApp(
         { featureName, configName, featureLoaders, config, options, envName: '${envName}', publicPath }

--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -16,7 +16,7 @@ export interface ICreateEntrypointsOptions {
     staticBuild: boolean;
     mode: 'production' | 'development';
     publicConfigsRoute?: string;
-    configMap: Record<string, TopLevelConfig>;
+    envInjectedConfig: Record<string, TopLevelConfig>;
 }
 interface IConfigFileMapping {
     filePath: string;
@@ -60,7 +60,7 @@ export function createEntrypoint({
     mode,
     staticBuild,
     publicConfigsRoute,
-    configMap,
+    envInjectedConfig,
 }: ICreateEntrypointsOptions) {
     const configs = getAllValidConfigurations(getConfigLoaders(configurations, mode, configName), envName);
     return `
@@ -121,7 +121,7 @@ async function main() {
     
     ${publicConfigsRoute ? fetchConfigs(publicConfigsRoute, envName) : ''}
     
-    ${configMap[envName] ? `config.push(...${JSON.stringify(configMap)})` : ``}
+    ${envInjectedConfig[envName] ? `config.push(...${JSON.stringify(envInjectedConfig)})` : ``}
     
     const runtimeEngine = await runEngineApp(
         { featureName, configName, featureLoaders, config, options, envName: '${envName}', publicPath }

--- a/packages/scripts/src/create-webpack-configs.ts
+++ b/packages/scripts/src/create-webpack-configs.ts
@@ -20,7 +20,7 @@ export interface ICreateWebpackConfigsOptions {
     configurations: SetMultiMap<string, IConfigDefinition>;
     staticBuild: boolean;
     publicConfigsRoute?: string;
-    config?: TopLevelConfig;
+    configMap?: Record<string, TopLevelConfig>;
 }
 
 const engineDashboardEntry = require.resolve('./engine-dashboard');
@@ -54,7 +54,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
         publicPath = '',
         featureName,
         features,
-        config,
+        configMap,
     } = options;
 
     const resolvedContexts = getResolvedContexts(features, featureName);
@@ -104,7 +104,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 virtualModules,
                 plugins,
                 entry,
-                config,
+                configMap,
             })
         );
     }
@@ -117,7 +117,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'webworker',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
-                config,
+                configMap,
             })
         );
     }
@@ -130,7 +130,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'electron-renderer',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
-                config,
+                configMap,
             })
         );
     }
@@ -144,7 +144,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'electron-main',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
-                config,
+                configMap,
             })
         );
     }
@@ -170,7 +170,7 @@ interface ICreateWebpackConfigOptions {
     configurations: SetMultiMap<string, IConfigDefinition>;
     staticBuild: boolean;
     publicConfigsRoute?: string;
-    config?: TopLevelConfig;
+    configMap?: Record<string, TopLevelConfig>;
 }
 
 function addEnv(envs: Map<string, string[]>, { name, childEnvName }: IEnvironment) {
@@ -199,7 +199,7 @@ function createWebpackConfig({
     configurations,
     staticBuild,
     publicConfigsRoute,
-    config = [],
+    configMap = {},
 }: ICreateWebpackConfigOptions): webpack.Configuration {
     for (const [envName, childEnvs] of enviroments) {
         const entryPath = fs.join(context, `${envName}-${target}-entry.js`);
@@ -215,7 +215,7 @@ function createWebpackConfig({
             mode,
             staticBuild,
             publicConfigsRoute,
-            config,
+            configMap,
         });
         if (target === 'web' || target === 'electron-renderer') {
             plugins.push(

--- a/packages/scripts/src/create-webpack-configs.ts
+++ b/packages/scripts/src/create-webpack-configs.ts
@@ -2,7 +2,7 @@ import fs from '@file-services/node';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import type webpack from 'webpack';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
-import { SetMultiMap } from '@wixc3/engine-core';
+import { SetMultiMap, TopLevelConfig } from '@wixc3/engine-core';
 import { createEntrypoint } from './create-entrypoint';
 import type { IEnvironment, IFeatureDefinition, IConfigDefinition } from './types';
 
@@ -20,6 +20,7 @@ export interface ICreateWebpackConfigsOptions {
     configurations: SetMultiMap<string, IConfigDefinition>;
     staticBuild: boolean;
     publicConfigsRoute?: string;
+    config?: TopLevelConfig;
 }
 
 const engineDashboardEntry = require.resolve('./engine-dashboard');
@@ -46,7 +47,15 @@ function getResolvedContexts(features: Map<string, IFeatureDefinition>, featureN
 }
 
 export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): webpack.Configuration[] {
-    const { enviroments, mode = 'development', baseConfig = {}, publicPath = '', featureName, features } = options;
+    const {
+        enviroments,
+        mode = 'development',
+        baseConfig = {},
+        publicPath = '',
+        featureName,
+        features,
+        config,
+    } = options;
 
     const resolvedContexts = getResolvedContexts(features, featureName);
 
@@ -95,6 +104,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 virtualModules,
                 plugins,
                 entry,
+                config,
             })
         );
     }
@@ -107,6 +117,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'webworker',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
+                config,
             })
         );
     }
@@ -119,6 +130,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'electron-renderer',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
+                config,
             })
         );
     }
@@ -132,6 +144,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'electron-main',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
+                config,
             })
         );
     }
@@ -157,6 +170,7 @@ interface ICreateWebpackConfigOptions {
     configurations: SetMultiMap<string, IConfigDefinition>;
     staticBuild: boolean;
     publicConfigsRoute?: string;
+    config?: TopLevelConfig;
 }
 
 function addEnv(envs: Map<string, string[]>, { name, childEnvName }: IEnvironment) {
@@ -185,6 +199,7 @@ function createWebpackConfig({
     configurations,
     staticBuild,
     publicConfigsRoute,
+    config = [],
 }: ICreateWebpackConfigOptions): webpack.Configuration {
     for (const [envName, childEnvs] of enviroments) {
         const entryPath = fs.join(context, `${envName}-${target}-entry.js`);
@@ -200,6 +215,7 @@ function createWebpackConfig({
             mode,
             staticBuild,
             publicConfigsRoute,
+            config,
         });
         if (target === 'web' || target === 'electron-renderer') {
             plugins.push(

--- a/packages/scripts/src/create-webpack-configs.ts
+++ b/packages/scripts/src/create-webpack-configs.ts
@@ -20,7 +20,7 @@ export interface ICreateWebpackConfigsOptions {
     configurations: SetMultiMap<string, IConfigDefinition>;
     staticBuild: boolean;
     publicConfigsRoute?: string;
-    configMap?: Record<string, TopLevelConfig>;
+    envInjectedConfig?: Record<string, TopLevelConfig>;
 }
 
 const engineDashboardEntry = require.resolve('./engine-dashboard');
@@ -54,7 +54,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
         publicPath = '',
         featureName,
         features,
-        configMap,
+        envInjectedConfig,
     } = options;
 
     const resolvedContexts = getResolvedContexts(features, featureName);
@@ -104,7 +104,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 virtualModules,
                 plugins,
                 entry,
-                configMap,
+                envInjectedConfig,
             })
         );
     }
@@ -117,7 +117,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'webworker',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
-                configMap,
+                envInjectedConfig,
             })
         );
     }
@@ -130,7 +130,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'electron-renderer',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
-                configMap,
+                envInjectedConfig,
             })
         );
     }
@@ -144,7 +144,7 @@ export function createWebpackConfigs(options: ICreateWebpackConfigsOptions): web
                 target: 'electron-main',
                 virtualModules,
                 plugins: [new VirtualModulesPlugin(virtualModules)],
-                configMap,
+                envInjectedConfig,
             })
         );
     }
@@ -170,7 +170,7 @@ interface ICreateWebpackConfigOptions {
     configurations: SetMultiMap<string, IConfigDefinition>;
     staticBuild: boolean;
     publicConfigsRoute?: string;
-    configMap?: Record<string, TopLevelConfig>;
+    envInjectedConfig?: Record<string, TopLevelConfig>;
 }
 
 function addEnv(envs: Map<string, string[]>, { name, childEnvName }: IEnvironment) {
@@ -199,7 +199,7 @@ function createWebpackConfig({
     configurations,
     staticBuild,
     publicConfigsRoute,
-    configMap = {},
+    envInjectedConfig = {},
 }: ICreateWebpackConfigOptions): webpack.Configuration {
     for (const [envName, childEnvs] of enviroments) {
         const entryPath = fs.join(context, `${envName}-${target}-entry.js`);
@@ -215,7 +215,7 @@ function createWebpackConfig({
             mode,
             staticBuild,
             publicConfigsRoute,
-            configMap,
+            envInjectedConfig,
         });
         if (target === 'web' || target === 'electron-renderer') {
             plugins.push(

--- a/packages/scripts/src/engine-router.ts
+++ b/packages/scripts/src/engine-router.ts
@@ -17,7 +17,7 @@ export function createFeaturesEngineRouter(
         const { configName, featureName, runtimeOptions: options, overrideConfig }: Required<IFeatureTarget> = req.body;
         try {
             let providedConfigName = configName;
-            if (overrideConfig) {
+            if (overrideConfig && Array.isArray(overrideConfig)) {
                 const generatedConfigName = generateConfigName(configName);
                 overrideConfigsMap.set(generatedConfigName, { overrideConfig, configName });
                 providedConfigName = generatedConfigName;

--- a/packages/scripts/src/node-environments-manager.ts
+++ b/packages/scripts/src/node-environments-manager.ts
@@ -15,6 +15,7 @@ import {
     IFeatureDefinition,
     isEnvironmentStartMessage,
     StartEnvironmentOptions,
+    TopLevelConfigProvider,
 } from './types';
 import type { OverrideConfig } from './config-middleware';
 import { filterEnvironments } from './utils/environments';
@@ -42,7 +43,7 @@ export interface INodeEnvironmentsManagerOptions {
     defaultRuntimeOptions?: Record<string, string | boolean>;
     port: number;
     inspect?: boolean;
-    overrideConfig: TopLevelConfig;
+    overrideConfig: TopLevelConfig | TopLevelConfigProvider;
 }
 
 export type LaunchEnvironmentMode = 'forked' | 'same-server' | 'new-server';
@@ -73,7 +74,6 @@ export class NodeEnvironmentsManager {
     }: RunEnvironmentOptions) {
         const runtimeConfigName = configName;
         const featureId = `${featureName}${configName ? delimiter + configName : ''}`;
-        const { overrideConfigs, originalConfigName } = this.getOverrideConfig(overrideConfigsMap, configName);
 
         const topology: Record<string, string> = {};
         const runningEnvironments: Record<string, number> = {};
@@ -87,6 +87,11 @@ export class NodeEnvironmentsManager {
             Object.assign(topology, this.getTopologyForRunningEnvironments(runningEnv.runningEnvironments));
         }
         for (const nodeEnv of filterEnvironments(featureName, features, 'node')) {
+            const { overrideConfigs, originalConfigName } = this.getOverrideConfig(
+                overrideConfigsMap,
+                configName,
+                nodeEnv.name
+            );
             const config: TopLevelConfig = [];
             config.push(COM.use({ config: { topology } }));
             config.push(...(await this.getConfig(originalConfigName)), ...overrideConfigs);
@@ -124,8 +129,14 @@ export class NodeEnvironmentsManager {
         };
     }
 
-    private getOverrideConfig(overrideConfigsMap: Map<string, OverrideConfig>, configName?: string) {
-        const overrideConfigs = [...this.options.overrideConfig];
+    private getOverrideConfig(overrideConfigsMap: Map<string, OverrideConfig>, configName?: string, envName?: string) {
+        const { overrideConfig: overrideConfigProvider } = this.options;
+        const overrideConfig = Array.isArray(overrideConfigProvider)
+            ? overrideConfigProvider
+            : envName
+            ? overrideConfigProvider(envName)
+            : [];
+        const overrideConfigs = [...overrideConfig];
         if (configName) {
             const currentOverrideConfig = overrideConfigsMap.get(configName);
             if (currentOverrideConfig) {

--- a/packages/scripts/src/node-environments-manager.ts
+++ b/packages/scripts/src/node-environments-manager.ts
@@ -140,8 +140,8 @@ export class NodeEnvironmentsManager {
         if (configName) {
             const currentOverrideConfig = overrideConfigsMap.get(configName);
             if (currentOverrideConfig) {
-                const { overrideConfig, configName: originalConfigName } = currentOverrideConfig;
-                overrideConfigs.push(...overrideConfig);
+                const { overrideConfig: topLevelConfig, configName: originalConfigName } = currentOverrideConfig;
+                overrideConfigs.push(...topLevelConfig);
                 return { overrideConfigs, originalConfigName };
             }
         }

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -9,11 +9,13 @@ import type {
 
 export type JSRuntime = 'web' | 'webworker' | 'node';
 
+export type TopLevelConfigProvider = (envName: string) => TopLevelConfig;
+
 export interface IFeatureTarget {
     featureName?: string;
     configName?: string;
     runtimeOptions?: Record<string, string | boolean>;
-    overrideConfig?: TopLevelConfig;
+    overrideConfig?: TopLevelConfig | TopLevelConfigProvider;
 }
 
 export interface StartEnvironmentOptions extends IEnvironment {

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -233,6 +233,8 @@ describe('Application', function () {
                 featureName: 'engine-single/x',
                 overrideConfig,
                 singleRun: true,
+                nodeEnvironmentsMode: 'forked',
+                mode: 'development',
             });
             disposables.add(() => close());
 

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -233,8 +233,34 @@ describe('Application', function () {
                 featureName: 'engine-single/x',
                 overrideConfig,
                 singleRun: true,
-                nodeEnvironmentsMode: 'forked',
-                mode: 'development',
+            });
+            disposables.add(() => close());
+
+            const page = await loadPage(`http://localhost:${port}/main.html`);
+            await waitFor(async () => {
+                const bodyContent = await getBodyContent(page);
+                if (bodyContent) {
+                    const [, bodyConfig] = bodyContent.split(': ');
+                    if (bodyConfig) {
+                        const parsedBodyConfig = JSON.parse(bodyConfig.trim());
+                        expect(parsedBodyConfig.value).to.eq(1);
+                    }
+                }
+            });
+        });
+
+        it('allows providing top level config through the config map', async () => {
+            const mainConfig: TopLevelConfig = [['XTestFeature', { config: { value: 1 } }]];
+            const app = new Application({
+                basePath: engineFeatureFixturePath,
+            });
+
+            const { close, port } = await app.start({
+                featureName: 'engine-single/x',
+                singleRun: true,
+                configMap: {
+                    main: mainConfig,
+                },
             });
             disposables.add(() => close());
 

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -258,9 +258,7 @@ describe('Application', function () {
             const { close, port } = await app.start({
                 featureName: 'engine-single/x',
                 singleRun: true,
-                envInjectedConfig: {
-                    main: mainConfig,
-                },
+                overrideConfig: () => mainConfig,
             });
             disposables.add(() => close());
 

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -258,7 +258,7 @@ describe('Application', function () {
             const { close, port } = await app.start({
                 featureName: 'engine-single/x',
                 singleRun: true,
-                configMap: {
+                envInjectedConfig: {
                     main: mainConfig,
                 },
             });


### PR DESCRIPTION
Currently, when using the Application API (in scripts) there is no way to build a feature (or start one) with a config. 