### PR TITLE
engineer: returning api or running dev server

### DIFF
--- a/packages/engineer/src/utils.ts
+++ b/packages/engineer/src/utils.ts
@@ -6,7 +6,7 @@ import {
     runNodeEnvironment,
     TopLevelConfigProvider,
 } from '@wixc3/engine-scripts';
-import { RuntimeEngine, BaseHost, TopLevelConfig, RuntimeFeature } from '@wixc3/engine-core';
+import { RuntimeEngine, BaseHost, TopLevelConfig, MapToProxyType } from '@wixc3/engine-core';
 
 import devServerFeature, { devServerEnv } from '../feature/dev-server.feature';
 import guiFeature from '../feature/gui.feature';
@@ -50,7 +50,7 @@ export async function startDevServer({
 }: IStartOptions): Promise<{
     dispose: () => Promise<void>;
     engine: RuntimeEngine;
-    devServerFeature: RuntimeFeature;
+    devServerFeature: MapToProxyType<typeof devServerFeature['api']>;
 }> {
     const basePath = resolve(__dirname, '../feature');
     const featurePaths = fs.findFilesSync(basePath, {
@@ -92,11 +92,10 @@ export async function startDevServer({
             }),
         ],
     });
-
     return {
         engine,
         dispose,
-        devServerFeature: engine.features.get(features.get('engineer/dev-server')!.exportedFeature) as RuntimeFeature,
+        devServerFeature: engine.get(devServerFeature).api,
     };
 }
 

--- a/packages/engineer/test/gui.unit.ts
+++ b/packages/engineer/test/gui.unit.ts
@@ -1,11 +1,10 @@
-import { createDisposables, Registry, RuntimeFeature } from '@wixc3/engine-core';
+import { createDisposables, RuntimeFeature } from '@wixc3/engine-core';
 import { createBrowserProvider } from '@wixc3/engine-test-kit';
 import fs from '@file-services/node';
 import guiFeature from '../feature/gui.feature';
 import { expect } from 'chai';
 import type { Page } from 'puppeteer';
 import { startDevServer } from '../src';
-import type { ServerListeningHandler } from '../feature/dev-server.feature';
 
 function getBodyContent(page: Page) {
     return page.evaluate(() => document.body.textContent!.trim());
@@ -25,11 +24,9 @@ describe('engineer:gui', function () {
         const runtimeFeature = engine.features.get(guiFeature) as RuntimeFeature;
 
         const runningPort = await new Promise<number>((resolve) => {
-            (devServerFeature.api.serverListeningHandlerSlot as Registry<ServerListeningHandler>).register(
-                ({ port }) => {
-                    resolve(port);
-                }
-            );
+            devServerFeature.serverListeningHandlerSlot.register(({ port }) => {
+                resolve(port);
+            });
         });
 
         disposables.add(() => dispose());


### PR DESCRIPTION
In engineer, instead of returning the instance of the running feature, when calling startDevServer, returning the feature's api