### PR TITLE
scripts: not pick up non-evaluated features

### DIFF
--- a/packages/scripts/src/analyze-feature.ts
+++ b/packages/scripts/src/analyze-feature.ts
@@ -93,10 +93,12 @@ export function loadFeaturesFromPaths(
     ownFeatureDirectoryPaths: Set<string>,
     fs: IFileSystemSync
 ) {
+    const foundFeatureFilePaths = new Set<string>(ownFeatureFilePaths);
     // find all require()'ed feature files from initial ones
     const featureModules = getFeatureModules(evaluateModule(Array.from(ownFeatureFilePaths)));
     const featureDirectoryPaths = new Set<string>(ownFeatureDirectoryPaths);
     for (const { filename } of featureModules) {
+        foundFeatureFilePaths.add(filename);
         featureDirectoryPaths.add(fs.dirname(filename));
     }
 
@@ -157,7 +159,9 @@ export function loadFeaturesFromPaths(
             const [evaluatedFeature] = evaluateModule(featureFilePath).children;
             const featureModule = analyzeFeatureModule(evaluatedFeature);
             const featureName = featureModule.name;
-
+            if (!foundFeatureFilePaths.has(featureFilePath)) {
+                continue;
+            }
             const scopedName = scopeToPackage(featurePackage.simplifiedName, featureName);
             foundFeatures.set(scopedName, {
                 ...featureModule,


### PR DESCRIPTION
currently analyze-features adds to the finds redundant features