### PR TITLE
scripts: pass socket config to node-env-manager

### DIFF
--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -90,14 +90,18 @@ devServerFeature.setup(
             //Node environment manager, need to add self to the topology, I thing starting the server and the NEM should happen in the setup and not in the run
             // So potential dependencies can rely on them in the topology
             application.setNodeEnvManager(
-                new NodeEnvironmentsManager(socketServer, {
-                    configurations,
-                    features,
-                    defaultRuntimeOptions,
-                    port: actualPort,
-                    inspect,
-                    overrideConfig,
-                })
+                new NodeEnvironmentsManager(
+                    socketServer,
+                    {
+                        configurations,
+                        features,
+                        defaultRuntimeOptions,
+                        port: actualPort,
+                        inspect,
+                        overrideConfig,
+                    },
+                    { ...socketServerOptions, ...configServerOptions }
+                )
             );
 
             disposables.add(() => application.getNodeEnvManager()?.closeAll());

--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -75,10 +75,12 @@ devServerFeature.setup(
                 await application.importModules(require);
             }
 
+            const resolvedSocketServerOptions = { ...configServerOptions, ...socketServerOptions };
+
             const { port: actualPort, app, close, socketServer } = await launchHttpServer({
                 staticDirPath: application.outputPath,
                 httpServerPort,
-                socketServerOptions: { ...socketServerOptions, ...configServerOptions },
+                socketServerOptions: resolvedSocketServerOptions,
             });
             disposables.add(() => close());
 
@@ -100,7 +102,7 @@ devServerFeature.setup(
                         inspect,
                         overrideConfig,
                     },
-                    { ...socketServerOptions, ...configServerOptions }
+                    resolvedSocketServerOptions
                 )
             );
 

--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -193,14 +193,18 @@ export class Application {
         const config: TopLevelConfig = [...(Array.isArray(userConfig) ? userConfig : [])];
         disposables.add(() => close());
 
-        const nodeEnvironmentManager = new NodeEnvironmentsManager(socketServer, {
-            features: new Map(features),
-            port,
-            defaultRuntimeOptions,
-            inspect,
-            overrideConfig: config,
-            configurations,
-        });
+        const nodeEnvironmentManager = new NodeEnvironmentsManager(
+            socketServer,
+            {
+                features: new Map(features),
+                port,
+                defaultRuntimeOptions,
+                inspect,
+                overrideConfig: config,
+                configurations,
+            },
+            engineConfig?.socketServerOptions
+        );
         disposables.add(() => nodeEnvironmentManager.closeAll());
 
         if (engineConfig && engineConfig.serveStatic) {

--- a/packages/scripts/src/node-environments-manager.ts
+++ b/packages/scripts/src/node-environments-manager.ts
@@ -63,7 +63,11 @@ export interface ILaunchEnvironmentOptions {
 export class NodeEnvironmentsManager {
     private runningEnvironments = new Map<string, IRuntimeEnvironment>();
 
-    constructor(private socketServer: io.Server, private options: INodeEnvironmentsManagerOptions) {}
+    constructor(
+        private socketServer: io.Server,
+        private options: INodeEnvironmentsManagerOptions,
+        private socketServerOptions?: SocketIO.ServerOptions
+    ) {}
 
     public async runServerEnvironments({
         featureName,
@@ -228,7 +232,7 @@ export class NodeEnvironmentsManager {
 
     private async runEnvironmentInNewServer(port: number, serverEnvironmentOptions: StartEnvironmentOptions) {
         const { httpServer, port: realPort } = await safeListeningHttpServer(port);
-        const socketServer = io(httpServer);
+        const socketServer = io(httpServer, this.socketServerOptions);
 
         const { close } = await runWSEnvironment(socketServer, serverEnvironmentOptions);
         const openSockets = new Set<Socket>();


### PR DESCRIPTION
Pass socket server configuration to node environment manager for `runEnvironmentInNewServer`