### PR TITLE
core-node: install required @types

### DIFF
--- a/examples/preload/globals.d.ts
+++ b/examples/preload/globals.d.ts
@@ -1,4 +1,2 @@
-declare namespace globalThis {
-    // eslint-disable-next-line no-var
-    var envMessages: string[];
-}
+// eslint-disable-next-line no-var
+declare var envMessages: string[];

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -8,6 +8,8 @@
     "test:node": "mocha \"test/**/*.unit.ts?(x)\""
   },
   "dependencies": {
+    "@types/cookie": "*",
+    "@types/cors": "*",
     "@wixc3/engine-core": "^16.2.0",
     "create-listening-server": "^1.0.0",
     "express": "^4.17.1",

--- a/packages/core/src/globals.d.ts
+++ b/packages/core/src/globals.d.ts
@@ -1,5 +1,4 @@
-namespace globalThis {
-    // used by communication to determine the type of environment
-    // we want to avoid having @types/node in engine-core
-    const process: { title?: string; type?: string } | undefined;
-}
+// used by communication to determine the type of environment
+// we want to avoid having @types/node in engine-core
+// eslint-disable-next-line no-var
+declare var process: { title?: string; type?: string } | undefined;

--- a/packages/scripts/src/top-level-config-loader.ts
+++ b/packages/scripts/src/top-level-config-loader.ts
@@ -5,15 +5,15 @@ export default function topLevelConfigLoader(this: webpackLoader.LoaderContext) 
 
     const fileName = params.get('scopedName');
     const envName = params.get('envName');
-
-    const cachedModule = require.cache[this.resourcePath];
-
+    const cachedModule = require.cache[this.resourcePath] as NodeModule | undefined;
     const imported = requireDeepHack(this.resourcePath, this.rootContext);
-    walkChildModules(cachedModule, ({ filename }) => {
-        if (!filename.includes('node_modules') && filename.includes(this.rootContext)) {
-            this.addDependency(filename);
-        }
-    });
+    if (cachedModule) {
+        walkChildModules(cachedModule, ({ filename }) => {
+            if (!filename.includes('node_modules') && filename.includes(this.rootContext)) {
+                this.addDependency(filename);
+            }
+        });
+    }
     const importedString = JSON.stringify(imported);
 
     const configFileName = envName ? `${fileName!}.${envName}` : fileName;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -67,7 +67,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    // "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,7 +1197,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cors@^2.8.8":
+"@types/cookie@*":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.0.tgz#14f854c0f93d326e39da6e3b6f34f7d37513d108"
+  integrity sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==
+
+"@types/cors@*", "@types/cors@^2.8.8":
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.8.tgz#317a8d8561995c60e35b9e0fcaa8d36660c98092"
   integrity sha512-fO3gf3DxU2Trcbr75O7obVndW/X5k8rJNZkLXlQWStTHhP71PkRqjwPIEI0yMnJdg9R9OasjU+Bsr+Hr1xy/0w==
@@ -1319,15 +1324,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.9.55"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.55.tgz#47078587f5bfe028a23b6b46c7b94ac0d436acff"
-  integrity sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16.9.56":
+"@types/react@*", "@types/react@^16.9.56":
   version "16.9.56"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.56.tgz#ea25847b53c5bec064933095fc366b1462e2adf0"
   integrity sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==
@@ -2594,9 +2591,9 @@ cliui@^5.0.0:
     wrap-ansi "^5.1.0"
 
 cliui@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.3.tgz#ef180f26c8d9bff3927ee52428bfec2090427981"
-  integrity sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
@@ -3492,9 +3489,9 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
     once "^1.4.0"
 
 engine.io-client@~4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-4.0.1.tgz#476ae6237d5d0ce44e964bb8ed376c934c7a80b3"
-  integrity sha512-3XXfWrEutlf1vg5PlS805bD+AgZXhRIKYAG04f1iCGOs70dWEYlZGfCZUNwPwNx05lBCKs1lIeL3SkLB0P++xw==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-4.0.2.tgz#947479b45931d0e63b84f2242fc7a4ae954db5e4"
+  integrity sha512-cfzFu0u7rr/Gmz/CefwZ6mBj9kxtsOtOavV/YLbn+2sPGE1ZTSWh3tj8427a0od+BK27zsWDpnDx98fnpnmksA==
   dependencies:
     base64-arraybuffer "0.1.4"
     component-emitter "~1.3.0"
@@ -3513,9 +3510,9 @@ engine.io-parser@~4.0.0, engine.io-parser@~4.0.1:
   integrity sha512-v5aZK1hlckcJDGmHz3W8xvI3NUHYc9t8QtTbqdR5OaH3S9iJZilPubauOm+vLWOMMWzpE3hiq92l9lTAHamRCg==
 
 engine.io@~4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-4.0.1.tgz#3004d1dabedd823679b7a297e77a00e0e528029d"
-  integrity sha512-6EaSBxasBUwxRdf6B68SEYpD3tcrG80J4YTzHl/D+9Q+vM0AMHZabfYcc2WdnvEaQxZjX/UZsa+UdGoM0qQQkQ==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-4.0.2.tgz#82d5788cb50c408102f59f3598f2e62f53191e95"
+  integrity sha512-sumdttqWLNjbuSMOSgDdL2xiEld9s5QZDk9VLyr4e28o+lzNNADhU3qpQDAY7cm2VZH0Otw/U0fL8mEjZ6kBMg==
   dependencies:
     accepts "~1.3.4"
     base64id "2.0.0"
@@ -9259,9 +9256,9 @@ yargs-parser@^15.0.1:
     decamelize "^1.2.0"
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.3.tgz#92419ba867b858c868acf8bae9bf74af0dd0ce26"
-  integrity sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-unparser@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- socket.io@3 references two libraries without built-in .d.ts files, so either we install it or the user will.
- using "*", to be consistent with @types packages and how they reference dependencies. "*" dedupes well in npm. yarn installs latest.
- fixed globals.d.ts in core and preload (now that .d.ts files are checked.
- fixed duplicate @types/react being installed.
- ensured topLevelConfigLoader is @types/node@14 compatible.