### PR TITLE
com: avoid redundant forwarding of messages

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -1,11 +1,4 @@
-import {
-    CALLBACK_TIMEOUT,
-    DUPLICATE_REGISTER,
-    MISSING_ENV,
-    REMOTE_CALL_FAILED,
-    reportError,
-    UNKNOWN_CALLBACK_ID,
-} from './errors';
+import { CALLBACK_TIMEOUT, DUPLICATE_REGISTER, REMOTE_CALL_FAILED, reportError, UNKNOWN_CALLBACK_ID } from './errors';
 import { isWindow, isWorkerContext, MultiCounter } from './helpers';
 import type {
     CallbackMessage,
@@ -520,14 +513,10 @@ export class Communication {
         }
     }
     private sendTo(envId: string, message: Message): void {
-        const start = this.resolveMessageTarget(envId);
-        if (!start) {
-            throw new Error(MISSING_ENV(envId, Object.keys(this.environments)));
-        }
         if (this.pendingEnvs.get(envId)) {
-            this.pendingMessages.add(envId, () => this.post(start, message));
+            this.pendingMessages.add(envId, () => this.post(this.resolveMessageTarget(envId), message));
         } else {
-            this.post(start, message);
+            this.post(this.resolveMessageTarget(envId), message);
         }
     }
 


### PR DESCRIPTION
When calling a remote API, before the environment is available, we register the a callback to send the message once the environment is ready.
But the target will always be to self, which will forward message to the second environment.
This caused the communication state to be invalid in forward listening messages