### PR TITLE
fix(test-kit): use puppeteer's default ws com

### DIFF
--- a/packages/test-kit/src/create-browser-provider.ts
+++ b/packages/test-kit/src/create-browser-provider.ts
@@ -5,7 +5,7 @@ export function createBrowserProvider(options?: LaunchOptions) {
     return {
         async loadPage(url: string) {
             if (!browser) {
-                browser = await launch({ ...options, pipe: true });
+                browser = await launch(options);
             }
             const page = await browser.newPage();
             await page.goto(url, { waitUntil: 'networkidle0' });

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -143,7 +143,6 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
             browser = await puppeteer.launch({
                 ...withFeatureOptions,
                 defaultViewport: undefined,
-                pipe: true,
             });
         }
     });


### PR DESCRIPTION
instead of pipe, which was required for previous versions