### PR TITLE
test(scripts): use waitFor; skip false-positives

### DIFF
--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -7,7 +7,7 @@ import type { Page } from 'puppeteer';
 import { Application } from '@wixc3/engine-scripts';
 
 function getBodyContent(page: Page) {
-    return page.evaluate(() => document.body.textContent!.trim());
+    return page.evaluate(() => (document.body.textContent || '').trim());
 }
 
 describe('Application', function () {
@@ -56,9 +56,10 @@ describe('Application', function () {
 
             const page = await loadPage(`http://localhost:${port}/main.html`);
 
-            const text = await getBodyContent(page);
-
-            expect(text).to.include('App is running');
+            await waitFor(async () => {
+                const text = await getBodyContent(page);
+                expect(text).to.include('App is running');
+            });
         });
 
         it(`launches a built application with node environment`, async () => {
@@ -76,9 +77,10 @@ describe('Application', function () {
 
             const page = await loadPage(`http://localhost:${port}/main.html`);
 
-            const text = await getBodyContent(page);
-
-            expect(text).to.equal('Hello');
+            await waitFor(async () => {
+                const text = await getBodyContent(page);
+                expect(text).to.equal('Hello');
+            });
         });
 
         it('allows providing top level config through the override config on build', async () => {
@@ -102,13 +104,9 @@ describe('Application', function () {
             const page = await loadPage(`http://localhost:${port}/main.html`);
             await waitFor(async () => {
                 const bodyContent = await getBodyContent(page);
-                if (bodyContent) {
-                    const [, bodyConfig] = bodyContent.split(': ');
-                    if (bodyConfig) {
-                        const parsedBodyConfig = JSON.parse(bodyConfig.trim()) as { value: number };
-                        expect(parsedBodyConfig.value).to.eq(1);
-                    }
-                }
+                const [, bodyConfig] = bodyContent.split(': ');
+                const parsedBodyConfig = JSON.parse(bodyConfig.trim()) as { value: number };
+                expect(parsedBodyConfig.value).to.eq(1);
             });
         });
 
@@ -117,37 +115,40 @@ describe('Application', function () {
             await app.build({
                 publicConfigsRoute: 'configs',
             });
-            const { close: webWorkerServer, port: webWorkerAppPort } = await app.run({
+            const { close, port: webWorkerAppPort } = await app.run({
                 featureName: 'contextual/some-feature',
                 publicConfigsRoute: 'configs',
             });
             disposables.add(() => app.clean());
-            disposables.add(() => webWorkerServer());
+            disposables.add(close);
 
             const webWorkerAppPage = await loadPage(
                 `http://localhost:${webWorkerAppPort}/main.html?feature=contextual/some-feature`
             );
 
-            const textFromWebWorker = await getBodyContent(webWorkerAppPage);
-
-            expect(textFromWebWorker).to.contain('worker');
+            await waitFor(async () => {
+                const textFromWebWorker = await getBodyContent(webWorkerAppPage);
+                expect(textFromWebWorker).to.contain('worker');
+            });
 
             const { close: closeServer, port: serverAppPort } = await app.run({
                 featureName: 'contextual/server-env',
                 publicConfigsRoute: 'configs',
             });
-            disposables.add(() => closeServer());
+            disposables.add(closeServer);
 
             const serverAppPage = await loadPage(
                 `http://localhost:${serverAppPort}/main.html?feature=contextual/server-env`
             );
 
-            const textFromServer = await getBodyContent(serverAppPage);
-
-            expect(textFromServer).to.contain('server');
+            await waitFor(async () => {
+                const textFromServer = await getBodyContent(serverAppPage);
+                expect(textFromServer).to.contain('server');
+            });
         });
 
-        it('allows providing top level config', async () => {
+        // was false positive due to if statements inside the waitFor causing noop
+        it.skip('allows providing top level config', async () => {
             const overrideConfig: TopLevelConfig = [['XTestFeature', { config: { value: 1 } }]];
             const app = new Application({
                 basePath: engineFeatureFixturePath,
@@ -160,21 +161,19 @@ describe('Application', function () {
                 overrideConfig,
             });
             disposables.add(close);
-
             const page = await loadPage(`http://localhost:${port}/main.html`);
+
             await waitFor(async () => {
                 const bodyContent = await getBodyContent(page);
-                if (bodyContent) {
-                    const [, bodyConfig] = bodyContent.split(': ');
-                    if (bodyConfig) {
-                        const parsedBodyConfig = JSON.parse(bodyConfig.trim()) as { value: number };
-                        expect(parsedBodyConfig.value).to.eq(1);
-                    }
-                }
+                const [, bodyConfig] = bodyContent.split(': ');
+                expect(bodyConfig).to.not.equal(undefined);
+                const parsedBodyConfig = JSON.parse(bodyConfig.trim()) as { value: number };
+                expect(parsedBodyConfig.value).to.eq(1);
             });
         });
 
-        it('allows providing top level config and config name', async () => {
+        // was false positive due to if statements inside the waitFor causing noop
+        it.skip('allows providing top level config and config name', async () => {
             const overrideConfig: TopLevelConfig = [['XTestFeature', { config: { value: 1 } }]];
             const app = new Application({
                 basePath: engineFeatureFixturePath,
@@ -190,15 +189,13 @@ describe('Application', function () {
             disposables.add(close);
 
             const page = await loadPage(`http://localhost:${port}/main.html`);
+
             await waitFor(async () => {
                 const bodyContent = await getBodyContent(page);
-                if (bodyContent) {
-                    const [, bodyConfig] = bodyContent.split(': ');
-                    if (bodyConfig) {
-                        const parsedBodyConfig = JSON.parse(bodyConfig.trim()) as { value: number };
-                        expect(parsedBodyConfig.value).to.eq(1);
-                    }
-                }
+                const [, bodyConfig] = bodyContent.split(': ');
+                expect(bodyConfig).to.not.equal(undefined);
+                const parsedBodyConfig = JSON.parse(bodyConfig.trim()) as { value: number };
+                expect(parsedBodyConfig.value).to.eq(1);
             });
         });
     });
@@ -211,9 +208,11 @@ describe('Application', function () {
         disposables.add(() => app.clean());
         const { close, port, router } = await app.run({ singleRun: true });
         disposables.add(close);
+
         router.get('/test/me', (_req, res) => {
             res.send('OK');
         });
+
         const page = await loadPage(`http://localhost:${port}/test/me`);
         expect(await page.content()).to.include('OK');
     });


### PR DESCRIPTION
- our app is dynamically loading, so we want to wait for the body to load (or we get flakiness in slower CI).
- two tests injecting stuff to Application.run() were already broken. The if statements inside the waitFor caused noop to happen, as waitFor expects a throw/rejection to retry. noop means all is good in tests, so false positive.