### PR TITLE
fix(test-kit): warn when non-node env runs on node

### DIFF
--- a/examples/file-server/test/file-server.unit.ts
+++ b/examples/file-server/test/file-server.unit.ts
@@ -14,7 +14,6 @@ describe('Processing env test', () => {
             runtimeOptions: {
                 projectPath: __dirname,
             },
-            fs,
             feature: Feature,
         });
 

--- a/examples/multi-env/test/file-server.unit.ts
+++ b/examples/multi-env/test/file-server.unit.ts
@@ -1,7 +1,6 @@
 import { getRunningFeature } from '@wixc3/engine-test-kit';
 import Feature, { processingEnv } from '../feature/multi-env.feature';
 import { expect } from 'chai';
-import fs from '@file-services/node';
 
 describe('Processing env test', () => {
     it('echos from node env', async () => {
@@ -11,7 +10,6 @@ describe('Processing env test', () => {
             runtimeOptions: {
                 projectPath: __dirname,
             },
-            fs,
             feature: Feature,
         });
 


### PR DESCRIPTION
Currently we dont validate that the environment being evaluated in node, should evaluate there.
At the first phase we will warn (with the ability to throw) when running envs of wrong targets on node, and leter will throw.
Also deprecating the usage of the fs in that method

+ allow providing feature deiscovery root for compatibility