### PR TITLE
fix(scripts): resolve external features from proper path

### DIFF
--- a/packages/engineer/src/application-proxy-service.ts
+++ b/packages/engineer/src/application-proxy-service.ts
@@ -11,6 +11,7 @@ import {
     ICompilerOptions,
     OverrideConfig,
     INpmPackage,
+    IExternalDefinition,
 } from '@wixc3/engine-scripts';
 import type { SetMultiMap } from '@wixc3/engine-core';
 import performance from '@wixc3/cross-performance';
@@ -62,6 +63,20 @@ export class TargetApplication extends Application {
 
     public createCompiler(compilerArgs: ICompilerOptions) {
         return super.createCompiler(compilerArgs);
+    }
+
+    public normilizeDefinitionsPackagePath(
+        externalFeatureDefinitions: IExternalDefinition[],
+        providedExternalFeatuersPath?: string,
+        configExternalFeatuersPath?: string,
+        configPath?: string
+    ) {
+        return super.normilizeDefinitionsPackagePath(
+            externalFeatureDefinitions,
+            providedExternalFeatuersPath,
+            configExternalFeatuersPath,
+            configPath
+        );
     }
 
     public getFeatureEnvDefinitions(

--- a/packages/engineer/src/application-proxy-service.ts
+++ b/packages/engineer/src/application-proxy-service.ts
@@ -11,7 +11,6 @@ import {
     ICompilerOptions,
     OverrideConfig,
     INpmPackage,
-    EngineConfig,
 } from '@wixc3/engine-scripts';
 import type { SetMultiMap } from '@wixc3/engine-core';
 import performance from '@wixc3/cross-performance';
@@ -30,7 +29,7 @@ export class TargetApplication extends Application {
         this.nodeEnvironmentsMode = opts.nodeEnvironmentsMode;
     }
 
-    public getEngineConfig(): Promise<EngineConfig | undefined> {
+    public getEngineConfig() {
         return super.getEngineConfig();
     }
 

--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -80,7 +80,7 @@ devServerFeature.setup(
 
         run(async () => {
             // Should engine config be part of the dev experience of the engine????
-            const engineConfig = await application.getEngineConfig();
+            const { config: engineConfig, path: engineConfigPath } = await application.getEngineConfig();
 
             const {
                 externalFeatureDefinitions = [],
@@ -97,7 +97,9 @@ devServerFeature.setup(
                 ...configServerOptions,
             };
             const externalFeaturesPath = resolve(
-                providedExternalFeaturesPath ?? configExternalFeaturesPath ?? join(basePath, 'node_modules')
+                providedExternalFeaturesPath ??
+                    configExternalFeaturesPath ??
+                    join(engineConfigPath ? dirname(engineConfigPath) : basePath, 'node_modules')
             );
             externalFeatureDefinitions.push(...providedExternalDefinitions);
             const { port: actualPort, app, close, socketServer } = await launchHttpServer({
@@ -112,7 +114,6 @@ devServerFeature.setup(
             attachWSHost(socketServer, devServerEnv.env, communication);
 
             const { features, configurations, packages } = application.getFeatures(singleFeature, featureName);
-            const engineConfigPath = await application.getClosestEngineConfigPath();
             const externalFeatures = getExternalFeaturesMetadata(
                 externalFeatureDefinitions,
                 engineConfigPath ? dirname(engineConfigPath) : basePath,

--- a/packages/engineer/src/utils.ts
+++ b/packages/engineer/src/utils.ts
@@ -86,7 +86,7 @@ export async function startDevServer({
     });
     preRequire([...pathsToRequire, ...(require ?? [])], basePath);
 
-    const features = loadFeaturesFromPaths(new Set(featurePaths), new Set([basePath]), fs).features;
+    const { features } = loadFeaturesFromPaths(new Set(featurePaths), new Set([basePath]), fs);
 
     const externalFeatures = getExternalFeaturesMetadata(
         [...configDefs, ...externalFeatureDefinitions],

--- a/packages/engineer/src/utils.ts
+++ b/packages/engineer/src/utils.ts
@@ -14,7 +14,6 @@ import { RuntimeEngine, BaseHost, TopLevelConfig, MapToProxyType } from '@wixc3/
 import devServerFeature, { devServerEnv } from './feature/dev-server.feature';
 import guiFeature from './feature/gui.feature';
 import { TargetApplication } from './application-proxy-service';
-import { join } from 'path';
 
 const basePath = fs.join(__dirname, './feature');
 
@@ -88,10 +87,13 @@ export async function startDevServer({
 
     const { features } = loadFeaturesFromPaths(new Set(featurePaths), new Set([basePath]), fs);
 
+    const resolvedExternalFeaturesPath = fs.resolve(
+        externalFeaturesPath ?? (configExternalPath ? fs.dirname(engineConfigPath!) : basePath)
+    );
+
     const externalFeatures = getExternalFeaturesMetadata(
-        [...configDefs, ...externalFeatureDefinitions],
-        engineConfigPath ? fs.dirname(engineConfigPath) : targetApplicationPath,
-        externalFeaturesPath ?? configExternalPath ?? join(targetApplicationPath, 'node_modules')
+        app.normilizeDefinitionsPackagePath([...configDefs, ...externalFeatureDefinitions]),
+        resolvedExternalFeaturesPath
     );
     const { engine, dispose } = await runNodeEnvironment({
         featureName: engineerEntry,

--- a/packages/engineer/src/utils.ts
+++ b/packages/engineer/src/utils.ts
@@ -76,15 +76,18 @@ export async function startDevServer({
     const app = new TargetApplication({
         basePath: targetApplicationPath,
     });
+    const { config: engineConfig, path: engineConfigPath } = await app.getEngineConfig();
+
     const { externalFeatureDefinitions: configDefs = [], externalFeaturesPath: configExternalPath, require } =
-        (await app.getEngineConfig()) ?? {};
+        engineConfig ?? {};
+
     const featurePaths = fs.findFilesSync(basePath, {
         filterFile: ({ name }) => isFeatureFile(name),
     });
     preRequire([...pathsToRequire, ...(require ?? [])], basePath);
 
     const features = loadFeaturesFromPaths(new Set(featurePaths), new Set([basePath]), fs).features;
-    const engineConfigPath = await app.getClosestEngineConfigPath();
+
     const externalFeatures = getExternalFeaturesMetadata(
         [...configDefs, ...externalFeatureDefinitions],
         engineConfigPath ? fs.dirname(engineConfigPath) : targetApplicationPath,

--- a/packages/engineer/test/dev-server.unit.ts
+++ b/packages/engineer/test/dev-server.unit.ts
@@ -485,7 +485,6 @@ describe('engineer:dev-server', function () {
         await externalFeatureApp.build({
             external: true,
             featureName: externalFeatureName,
-            featureOutDir: 'dist',
         });
 
         fs.copyDirectorySync(

--- a/packages/engineer/test/dev-server.unit.ts
+++ b/packages/engineer/test/dev-server.unit.ts
@@ -511,6 +511,7 @@ describe('engineer:dev-server', function () {
                     packageName: '@fixture/application-external-feature',
                 },
             ],
+            externalFeaturesPath: pluginsFolderPath,
         });
         disposables.add(() => dispose());
 

--- a/packages/scripts/src/utils/external-features.ts
+++ b/packages/scripts/src/utils/external-features.ts
@@ -6,14 +6,13 @@ import type { IBuildManifest } from '../application';
 
 export function getExternalFeaturesMetadata(
     pluginDefinitions: IExternalDefinition[],
-    engineConfigPath: string,
-    pluginsBaseDirectory: string
+    basePath: string
 ): IExtenalFeatureDescriptor[] {
     // mapping a feature definition to the entries of each environment of that feature, per target
     return pluginDefinitions.map(({ packageName, outDir = 'dist', packagePath }) => {
         const packageBasePath = packagePath
-            ? fs.resolve(engineConfigPath, packagePath)
-            : join(pluginsBaseDirectory, packageName);
+            ? fs.resolve(basePath, packagePath)
+            : require.resolve(packageName, { paths: [basePath] });
         const { entryPoints, defaultFeatureName } = fs.readJsonFileSync(
             fs.join(packageBasePath, outDir, 'manifest.json')
         ) as IBuildManifest;

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -250,6 +250,7 @@ describe('Application', function () {
                 ],
                 autoLaunch: true,
                 publicConfigsRoute,
+                externalFeaturesPath: join(baseWebApplicationFixturePath, 'node_modules'),
             });
             disposables.add(() => close());
 

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -225,7 +225,6 @@ describe('Application', function () {
             await externalFeatureApp.build({
                 external: true,
                 featureName: externalFeatureName,
-                featureOutDir: 'dist',
             });
 
             fs.copyDirectorySync(applicationExternalFixturePath, join(pluginsFolderPath, name, 'dist'));
@@ -250,7 +249,6 @@ describe('Application', function () {
                 ],
                 autoLaunch: true,
                 publicConfigsRoute,
-                externalFeaturesPath: join(baseWebApplicationFixturePath, 'node_modules'),
             });
             disposables.add(() => close());
 


### PR DESCRIPTION
currently resolving external features base path from the application base path, but the more correct way to do it is if there is an engine config present - from it. 