### PR TITLE
fix(scripts): serve external features on run by default

### DIFF
--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -267,7 +267,7 @@ export class Application {
             nodeEnvironmentsMode = 'new-server',
             autoLaunch = true,
             externalFeaturesPath: providedExternalFeatuersPath,
-            serveExternalFeaturesPath: providedServeExternalFeaturesPath,
+            serveExternalFeaturesPath: providedServeExternalFeaturesPath = true,
             externalFeatureDefinitions: providedExternalFeaturesDefinitions = [],
             socketServerOptions: runtimeSocketServerOptions,
         } = runOptions;


### PR DESCRIPTION
The run command id application.ts doesn't serve the external features by default. this is a bug