### PR TITLE
fix(core): keep promise-returning fn as-is

### DIFF
--- a/packages/core/src/com/types.ts
+++ b/packages/core/src/com/types.ts
@@ -51,10 +51,13 @@ export type UnknownFunction = (...args: unknown[]) => unknown;
 export type AsyncApi<T> = {
     [P in keyof T]: P extends keyof ServiceConfig<T>
         ? MultiTanentProxyFunction<T, P extends string ? P : never>
+        : T[P] extends (...args: any[]) => PromiseLike<any>
+        ? T[P]
         : T[P] extends (...args: infer Args) => infer R
-        ? (...args: Args) => ValuePromise<R>
+        ? (...args: Args) => Promise<R>
         : never;
 };
+
 export interface EnvironmentInstanceToken {
     id: string;
 }

--- a/packages/core/test/node/api-type-check.spec.ts
+++ b/packages/core/test/node/api-type-check.spec.ts
@@ -72,6 +72,14 @@ const gui = new Feature({
     },
 });
 
+interface SomeApi {
+    someMethod: () => boolean;
+}
+
+type SomeApiPromisified = AsyncApi<SomeApi>;
+
+typeCheck((_: EQUAL<SomeApiPromisified, { someMethod(): Promise<boolean> }>) => true);
+
 typeCheck(
     (
         _runningDependencies: EQUAL<


### PR DESCRIPTION
closes #571

otherwise, using `ValuePromise<R>` causes `() => boolean` to get re-wrapped as `() => Promise<true> | Promise<false>`