### PR TITLE
 fix: loading html scripts with crossorigin

### DIFF
--- a/packages/scripts/src/create-webpack-configs.ts
+++ b/packages/scripts/src/create-webpack-configs.ts
@@ -14,6 +14,7 @@ import type { ExternalsFunctionElement, Configuration, Plugin, Entry, ExternalsE
 import type { SetMultiMap, TopLevelConfig } from '@wixc3/engine-core';
 import type { getResolvedEnvironments } from './utils/environments';
 import type { IFeatureDefinition, IConfigDefinition, TopLevelConfigProvider, IExtenalFeatureDescriptor } from './types';
+import { WebpackScriptAttributesPlugin } from './webpack-html-attributes-plugins';
 
 export interface ICreateWebpackConfigsOptions {
     baseConfig?: Configuration;
@@ -178,11 +179,18 @@ export function createWebpackConfig({
         });
         if (target === 'web' || target === 'electron-renderer') {
             plugins.push(
-                new HtmlWebpackPlugin({
-                    filename: `${envName}.html`,
-                    chunks: [envName],
-                    title,
-                })
+                ...[
+                    new HtmlWebpackPlugin({
+                        filename: `${envName}.html`,
+                        chunks: [envName],
+                        title,
+                    }),
+                    new WebpackScriptAttributesPlugin({
+                        scriptAttributes: {
+                            crossorigin: 'anonymous',
+                        },
+                    }),
+                ]
             );
         }
     }

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -15,3 +15,4 @@ export * from './node-environments-manager';
 export * from './types';
 export * from './utils';
 export * from './ws-environment';
+export * from './webpack-html-attributes-plugins';

--- a/packages/scripts/src/webpack-html-attributes-plugins.ts
+++ b/packages/scripts/src/webpack-html-attributes-plugins.ts
@@ -1,0 +1,21 @@
+import type webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+
+export class WebpackScriptAttributesPlugin implements webpack.Plugin {
+    constructor(private options: { scriptAttributes: Record<string, string> }) {}
+
+    public apply(compiler: webpack.Compiler) {
+        compiler.hooks.compilation.tap(WebpackScriptAttributesPlugin.name, (compilation) => {
+            HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tap(WebpackScriptAttributesPlugin.name, (tags) => {
+                const {
+                    assetTags: { scripts },
+                } = tags;
+
+                for (const tagObject of scripts) {
+                    Object.assign(tagObject.attributes, this.options.scriptAttributes);
+                }
+                return tags;
+            });
+        });
+    }
+}


### PR DESCRIPTION
adding crossorigin attribute to the environment's auto generated html