### PR TITLE
feat(core): preserve original error message in cross-env API calls

### DIFF
--- a/packages/core/src/com/errors.ts
+++ b/packages/core/src/com/errors.ts
@@ -3,8 +3,8 @@ import type { Message } from './message-types';
 export const DUPLICATE_REGISTER = (id: string, type: 'RemoteService' | 'Environment') =>
     `Could not register same id ${id} as ${type}`;
 export const GLOBAL_REF = (id: string) => `Com with id "${id}" is already running.`;
-export const REMOTE_CALL_FAILED = (message: Message) =>
-    `Remote call failed with error: "${message.error!}" from "${message.from}"`;
+export const REMOTE_CALL_FAILED = (environment: string, stack?: string) =>
+    `Remote call failed in ${environment}${stack ? `\n${stack}` : ''}`;
 export const UNKNOWN_CALLBACK_ID = (message: Message) =>
     `Unknown callback id "${message.callbackId!}" in message:\n${JSON.stringify(message)}`;
 export const CALLBACK_TIMEOUT = (callbackId: string, hostId: string, message: Message) =>

--- a/packages/core/src/com/message-types.ts
+++ b/packages/core/src/com/message-types.ts
@@ -10,7 +10,7 @@ export interface BaseMessage {
     to: string;
     from: string;
     callbackId?: string;
-    error?: string;
+    error?: Error;
     origin: string;
 }
 

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -4,3 +4,4 @@ export * from './set-multi-map';
 export * from './flatten-tree';
 export * from './disposables';
 export * from './web';
+export * from './serialize-error';

--- a/packages/core/src/helpers/serialize-error.ts
+++ b/packages/core/src/helpers/serialize-error.ts
@@ -1,0 +1,16 @@
+export function serializeError(error: unknown): Error {
+    if (error instanceof Error) {
+        return {
+            // Custom properties
+            ...error,
+            // Non-enumerable properties, can't be added via spread
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+        };
+    }
+    return {
+        name: 'Error',
+        message: typeof error === 'string' ? error : JSON.stringify(error),
+    };
+}

--- a/packages/core/test/communication.spec.ts
+++ b/packages/core/test/communication.spec.ts
@@ -15,6 +15,7 @@ import {
     testServiceId,
     HashParamsRetriever,
     hashParamsRetriever,
+    testServiceError,
 } from './test-api-service';
 
 describe('Communication API', function () {
@@ -57,6 +58,23 @@ describe('Communication API', function () {
         expect(res).to.eql({ echo: [1, 2, 3] });
     });
 
+    it('should proxy exceptions thrown in remote service api', async () => {
+        const com = disposables.add(new Communication(window, comId));
+
+        const env = await com.startEnvironment(
+            iframeEnv,
+            iframeInitializer({
+                iframeElement: createIframe(),
+            })
+        );
+
+        const api = com.apiProxy<TestService>(env, { id: testServiceId });
+        const error = await api.failWithError().catch((e: unknown) => e);
+
+        expect(error).to.be.instanceOf(Error);
+        expect(error).to.deep.include(testServiceError);
+    });
+
     it('should listen to remote api callbacks', async () => {
         const com = disposables.add(new Communication(window, comId));
 
@@ -97,7 +115,7 @@ describe('Communication API', function () {
         });
     });
 
-    it('handles a single tanent function in api services that have multi tanent functions', async () => {
+    it('handles a single tenant function in api services that have multi tenant functions', async () => {
         const com = disposables.add(new Communication(window, comId));
 
         const env = await com.startEnvironment(

--- a/packages/core/test/test-api-service.ts
+++ b/packages/core/test/test-api-service.ts
@@ -13,6 +13,11 @@ export class TestService {
         }
         return data;
     }
+    public failWithError(): void {
+        const error = new Error();
+        Object.assign(error, testServiceError);
+        throw error;
+    }
     public listen(fn: (x: ITestServiceData) => void) {
         this.listeners.push(fn);
     }
@@ -48,3 +53,9 @@ export const testServiceId = 'TestService';
 export const multiTanentServiceId = 'MultiTanentService';
 
 export const hashParamsRetriever = 'HashParamsRetriever';
+
+export const testServiceError = {
+    name: 'TestServiceError',
+    message: 'test service error',
+    code: 1
+};


### PR DESCRIPTION
Sometimes it's useful to show the error message that occurred in a remote API call to the user:

```ts
try {
    await service.doThing();
} catch (error) {
    setDialogError(error.message);
}
```

But currently we prefix each error with 'Remote call failed with error:', and also include the entire stack trace in the error message, which doesn't look good in the UI.

Additionally, we discard custom error properties, such as error code.

This PR changes error handing to preserve the error name, message, and custom properties. If the error is uncaught, it's useful for debugging to know from which environment it originated, and we add this extra info to `error.stack`. Chrome logs it in full to the console. Unfortunately, Firefox ignores `error.stack` and shows its own stack trace that's not derived from the error object.