### PR TITLE
fix(iframe location): fix iframe location change

### DIFF
--- a/packages/core/src/com/initializers/iframe.ts
+++ b/packages/core/src/com/initializers/iframe.ts
@@ -16,8 +16,6 @@ export function iframeInitializer({
     managed,
     src,
 }: IIframeInitializerOptions): EnvironmentInitializer<{ id: string }> {
-    console.log('test');
-
     return async (com, { env, endpointType }) => {
         const instanceId = com.getEnvironmentInstanceId(env, endpointType);
         const publicPath = com.getPublicPath();
@@ -77,7 +75,7 @@ async function useIframe(
     // this we add an unused URL param '?not-blank'.
 
     if (!iframe.contentWindow.location.href.startsWith('about:blank')) {
-        iframe.contentWindow.location.href = 'about:blank?not-blank';
+        iframe.contentWindow.location.replace('about:blank?not-blank');
         await Promise.race([waitForCancel, waitForLoad(iframe)]);
     }
 
@@ -93,8 +91,6 @@ async function useIframe(
         contentWindow.name = instanceId;
         com.registerEnv(instanceId, contentWindow);
         contentWindow.location.replace(href);
-        alert('test');
-        console.log('test');
         await Promise.race([waitForCancel, waitForLoad(iframe)]);
 
         if (iframe.contentWindow !== contentWindow || iframe.contentWindow.location.href !== href) {

--- a/packages/core/src/com/initializers/iframe.ts
+++ b/packages/core/src/com/initializers/iframe.ts
@@ -16,6 +16,8 @@ export function iframeInitializer({
     managed,
     src,
 }: IIframeInitializerOptions): EnvironmentInitializer<{ id: string }> {
+    console.log('test');
+
     return async (com, { env, endpointType }) => {
         const instanceId = com.getEnvironmentInstanceId(env, endpointType);
         const publicPath = com.getPublicPath();
@@ -90,8 +92,9 @@ async function useIframe(
         const contentWindow = iframe.contentWindow;
         contentWindow.name = instanceId;
         com.registerEnv(instanceId, contentWindow);
-        contentWindow.location.href = href;
-
+        contentWindow.location.replace(href);
+        alert('test');
+        console.log('test');
         await Promise.race([waitForCancel, waitForLoad(iframe)]);
 
         if (iframe.contentWindow !== contentWindow || iframe.contentWindow.location.href !== href) {


### PR DESCRIPTION
Changed the way we change iframe's url to `replace` instead of changing `location.href`, in this way it won't affect the history stack.

Fixes [#3306](https://github.com/wixplosives/component-studio/issues/3306)