### PR TITLE
fix(scripts): map to requests only if out dir inside base dir scope

### DIFF
--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -549,6 +549,7 @@ export class Application {
         configName?: string;
         entryPoints: Record<string, Record<string, string>>;
     }) {
+        const outputDirInBasePath = this.outputPath.includes(this.basePath);
         const manifest: IBuildManifest = {
             features: Array.from(features.entries()).map(
                 ([
@@ -573,28 +574,28 @@ export class Application {
                         filePath: getFilePathInPackage(
                             fs,
                             packageName,
-                            isRoot ? this.outputPath : directoryPath,
+                            isRoot && outputDirInBasePath ? this.outputPath : directoryPath,
                             filePath,
                             isRoot
                         ),
                         envFilePaths: scopeFilePathsToPackage(
                             fs,
                             packageName,
-                            isRoot ? this.outputPath : directoryPath,
+                            isRoot && outputDirInBasePath ? this.outputPath : directoryPath,
                             envFilePaths,
                             isRoot
                         ),
                         contextFilePaths: scopeFilePathsToPackage(
                             fs,
                             packageName,
-                            isRoot ? this.outputPath : directoryPath,
+                            isRoot && outputDirInBasePath ? this.outputPath : directoryPath,
                             contextFilePaths,
                             isRoot
                         ),
                         preloadFilePaths: scopeFilePathsToPackage(
                             fs,
                             packageName,
-                            isRoot ? this.outputPath : directoryPath,
+                            isRoot && outputDirInBasePath ? this.outputPath : directoryPath,
                             preloadFilePaths,
                             isRoot
                         ),

--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -549,7 +549,7 @@ export class Application {
         configName?: string;
         entryPoints: Record<string, Record<string, string>>;
     }) {
-        const outputDirInBasePath = this.outputPath.includes(this.basePath);
+        const outputDirInBasePath = this.outputPath.startsWith(this.basePath);
         const manifest: IBuildManifest = {
             features: Array.from(features.entries()).map(
                 ([


### PR DESCRIPTION
when mapping own requests to engine files in the manifest, we should not re-map to relative requests, unless the outdir is inside the base path. Otherwise resolution will fail