### PR TITLE
fix(core): improved node detection

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,9 @@
     "socket.io-client": "^3.1.2",
     "typescript-type-utils": "^0.1.0"
   },
+  "browser": {
+    "process": false
+  },
   "files": [
     "dist",
     "!dist/test",

--- a/packages/core/src/communication.feature.ts
+++ b/packages/core/src/communication.feature.ts
@@ -1,3 +1,4 @@
+import process from 'process';
 import { BaseHost } from './com/hosts/base-host';
 import { Communication, ICommunicationOptions } from './com/communication';
 import { LoggerService } from './com/logger-service';
@@ -59,8 +60,7 @@ export default new Feature({
         runningEnvironmentName,
         onDispose,
     }) => {
-        // TODO: find better way to detect node runtime
-        const isNode = typeof process !== 'undefined' && process.title !== 'browser' && process.type !== 'renderer';
+        const isNode = !!process.versions?.node && process.title !== 'browser' && process.type !== 'renderer';
 
         // worker and iframe always get `name` when initialized as Environment.
         // it can be overridden using top level config.

--- a/packages/core/src/globals.d.ts
+++ b/packages/core/src/globals.d.ts
@@ -1,4 +1,8 @@
 // used by communication to determine the type of environment
 // we want to avoid having @types/node in engine-core
 // eslint-disable-next-line no-var
-declare var process: { title?: string; type?: string } | undefined;
+
+declare module 'process' {
+    const process: { title?: string; type?: string; versions?: { node?: string } };
+    export = process;
+}

--- a/packages/core/test/webpack.config.js
+++ b/packages/core/test/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+/** @type {import('webpack').Configuration} */
 module.exports = {
     mode: 'development',
     context: __dirname,


### PR DESCRIPTION
- avoid using global process. instead, import it from `'process'` and map that to an empty object. `"browser"` field is picked by bundlers.
- also, ensure `process.versions.node` is truthy, for naive polyfills.