### PR TITLE
fix(scripts): properly re-mapping requests in manifest file

### DIFF
--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -135,7 +135,7 @@ export function buildCommand(program: typeof commander) {
         .option('--external [true|false]', 'build feature as external', parseBoolean, false)
         .option('--eagerEntrypoints [true|false]', 'build feature as external', parseBoolean, false)
         .option(
-            '--featureOutDir <featureOutDir>',
+            '--sourcesRoot <sourcesRoot>',
             'the directory where the feature library will be published at (relative to the base path). default: "."'
         )
         .option(
@@ -170,7 +170,7 @@ export function buildCommand(program: typeof commander) {
                 publicConfigsRoute,
                 webpackConfig,
                 external,
-                featureOutDir,
+                sourcesRoot,
                 withExternalFeatures,
                 fetchExternalFeatures,
                 eagerEntrypoints,
@@ -193,7 +193,7 @@ export function buildCommand(program: typeof commander) {
                     publicConfigsRoute,
                     webpackConfigPath: webpackConfig,
                     external,
-                    featureOutDir,
+                    sourcesRoot,
                     withExternalFeatures,
                     fetchExternalFeatures,
                     eagerEntrypoint: eagerEntrypoints,

--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -596,7 +596,6 @@ export class Application {
                         for (const [envName, filePath] of Object.entries(preloadFilePaths)) {
                             envFilePaths[envName] = filePath.replace(directoryPath, featureOutDir);
                         }
-                        // directoryPath = featureOutDir;
                     }
                     return [
                         featureName,

--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -263,7 +263,7 @@ export class Application {
             featureName,
             configName,
             entryPoints,
-            featureOutDir: fs.resolve(this.basePath, bundledSourcesRoot),
+            featureOutDir: bundledSourcesRoot,
         });
 
         return stats;
@@ -597,6 +597,7 @@ export class Application {
                             envFilePaths[envName] = filePath.replace(directoryPath, featureOutDir);
                         }
                     }
+                    const context = isRoot && outputDirInBasePath ? this.outputPath : directoryPath;
                     return [
                         featureName,
                         {
@@ -604,28 +605,28 @@ export class Application {
                             filePath: getFilePathInPackage(
                                 fs,
                                 packageName,
-                                directoryPath,
+                                context,
                                 filePath,
                                 isRoot && outputDirInBasePath
                             ),
                             envFilePaths: scopeFilePathsToPackage(
                                 fs,
                                 packageName,
-                                directoryPath,
+                                context,
                                 envFilePaths,
                                 isRoot && outputDirInBasePath
                             ),
                             contextFilePaths: scopeFilePathsToPackage(
                                 fs,
                                 packageName,
-                                directoryPath,
+                                context,
                                 contextFilePaths,
                                 isRoot && outputDirInBasePath
                             ),
                             preloadFilePaths: scopeFilePathsToPackage(
                                 fs,
                                 packageName,
-                                directoryPath,
+                                context,
                                 preloadFilePaths,
                                 isRoot && outputDirInBasePath
                             ),

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -295,6 +295,6 @@ export interface EngineConfig {
     externalFeaturesPath?: string;
     serveExternalFeaturesPath?: boolean;
     socketServerOptions?: Partial<io.ServerOptions>;
-    featureOutDir?: string;
+    sourcesRoot?: string;
     favicon?: string;
 }

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -199,7 +199,7 @@ describe('Application', function () {
                 expect(loadedModule).to.not.eq({});
             });
 
-            it('creates a node entry with re-mapped sources', async () => {
+            it.only('creates a node entry with re-mapped sources', async () => {
                 const tempDirPath = fs.join(os.tmpdir(), mkdtempSync('some-test'));
                 fs.copyDirectorySync(nodeFeatureFixturePath, tempDirPath);
                 disposables.add(() => rimraf.sync(tempDirPath));
@@ -208,10 +208,9 @@ describe('Application', function () {
                     fs.join(tempDirPath, 'node_modules'),
                     'junction'
                 );
-                fs.symlinkSync(
+                fs.copyFileSync(
                     fs.join(__dirname, '../../../webpack.config.js'),
-                    fs.join(tempDirPath, 'webpack.config.js'),
-                    'file'
+                    fs.join(tempDirPath, 'webpack.config.js')
                 );
 
                 const app = new Application({ basePath: tempDirPath });

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -201,19 +201,13 @@ describe('Application', function () {
 
             it('creates a node entry with re-mapped sources', async () => {
                 const tempDirPath = fs.join(os.tmpdir(), mkdtempSync('some-test'));
-                fs.copyDirectorySync(nodeFeatureFixturePath, tempDirPath);
-                disposables.add(() => rimraf.sync(tempDirPath));
-                fs.symlinkSync(
-                    fs.join(__dirname, '../../../node_modules'),
-                    fs.join(tempDirPath, 'node_modules'),
-                    'junction'
-                );
-                fs.copyFileSync(
-                    fs.join(__dirname, '../../../webpack.config.js'),
-                    fs.join(tempDirPath, 'webpack.config.js')
-                );
 
-                const app = new Application({ basePath: tempDirPath });
+                disposables.add(() => rimraf.sync(tempDirPath));
+
+                const app = new Application({
+                    basePath: nodeFeatureFixturePath,
+                    outputPath: fs.join(tempDirPath, 'dist'),
+                });
                 await app.build({ external: true, featureName: 'engine-node/x', sourcesRoot: 'lib' });
 
                 disposables.add(() => app.clean());
@@ -226,8 +220,14 @@ describe('Application', function () {
                 )) as Record<string, IFeatureLoader>;
                 expect(nodeEntryModule['engine-node/x']).to.not.eq(undefined);
 
+                fs.symlinkSync(
+                    fs.join(__dirname, '../../../node_modules'),
+                    fs.join(tempDirPath, 'node_modules'),
+                    'junction'
+                );
+
                 await expect(nodeEntryModule['engine-node/x']?.load({})).to.eventually.be.rejectedWith();
-                fs.copyDirectorySync(fs.join(tempDirPath, 'feature'), fs.join(tempDirPath, 'lib/feature'));
+                fs.copyDirectorySync(fs.join(nodeFeatureFixturePath, 'feature'), fs.join(tempDirPath, 'lib/feature'));
                 await expect(nodeEntryModule['engine-node/x']?.load({})).to.eventually.not.be.rejectedWith();
             });
         });

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -199,7 +199,7 @@ describe('Application', function () {
                 expect(loadedModule).to.not.eq({});
             });
 
-            it.only('creates a node entry with re-mapped sources', async () => {
+            it('creates a node entry with re-mapped sources', async () => {
                 const tempDirPath = fs.join(os.tmpdir(), mkdtempSync('some-test'));
                 fs.copyDirectorySync(nodeFeatureFixturePath, tempDirPath);
                 disposables.add(() => rimraf.sync(tempDirPath));

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -126,7 +126,7 @@ describe('Application', function () {
                 const manifestFilePath = fs.join(app.outputPath, manifestFileName);
                 await app.build({
                     featureName: 'engine-single/x',
-                    featureOutDir: 'lib',
+                    sourcesRoot: 'lib',
                 });
                 disposables.add(() => app.clean());
                 const manifest = JSON.parse(fs.readFileSync(manifestFilePath, 'utf-8')) as IBuildManifest;
@@ -161,7 +161,7 @@ describe('Application', function () {
                 const manifestFilePath = fs.join(app.outputPath, manifestFileName);
                 await app.build({
                     featureName: 'engine-single/x',
-                    featureOutDir: 'dist',
+                    sourcesRoot: 'lib',
                 });
                 disposables.add(() => app.clean());
                 const manifest = JSON.parse(fs.readFileSync(manifestFilePath, 'utf-8')) as IBuildManifest;
@@ -169,7 +169,7 @@ describe('Application', function () {
                 const featureDefinition = manifest.features.find(([featureName]) => featureName === 'engine-single/x');
                 expect(featureDefinition).to.not.be.undefined;
                 const [, { filePath }] = featureDefinition!;
-                expect(filePath).to.eq('@fixture/engine-single-feature/dist/feature/x.feature');
+                expect(filePath).to.eq('@fixture/engine-single-feature/lib/feature/x.feature');
             });
         });
 
@@ -216,7 +216,7 @@ describe('Application', function () {
                 );
 
                 const app = new Application({ basePath: tempDirPath });
-                await app.build({ external: true, featureName: 'engine-node/x', featureOutDir: 'lib' });
+                await app.build({ external: true, featureName: 'engine-node/x', sourcesRoot: 'lib' });
 
                 disposables.add(() => app.clean());
 


### PR DESCRIPTION
Using the featureOutDir in in build command, to point to the bundled sources of the application, and fall back to featureDiscovery root