### PR TITLE
hotfix(script): don't normalize externals route

### DIFF
--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -464,7 +464,7 @@ function getExternalFeaturesFromParent(externalFeaturesRoute: string) {
 }
 
 function fetchExternalFeatures(externalFeaturesRoute: string) {
-    return `return (await fetch('${normalizeRoute(externalFeaturesRoute)!}')).json()`;
+    return `return (await fetch('${externalFeaturesRoute}')).json()`;
 }
 
 function fetchFeaturesFromElectronProcess(externalFeaturesRoute: string) {


### PR DESCRIPTION
we no longer need to normalize route to request, since it's a request to a file