### PR TITLE
hotfix(scripts): returning the externals route

### DIFF
--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -415,6 +415,13 @@ export class Application {
         });
         disposables.add(close);
 
+        // since the latest release was a patch, We need to be backward compatible with broken changes.
+        // adding backward compatibility for previous engine versions.
+        // todo: remove this on next major
+        app.get('/external', (_, res) => {
+            res.json(externalFeatures);
+        });
+
         fixedExternalFeatureDefinitions.push(
             ...this.normilizeDefinitionsPackagePath(
                 providedExternalFeaturesDefinitions,


### PR DESCRIPTION
After deciding that the latest version was a minor, I found a place that is not backward compatible.

Adding backward compatibility by adding the previous route middleware to response to the /external request