### PR TITLE
fix(scripts): importing external features only if defined

### DIFF
--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -140,8 +140,7 @@ export function buildCommand(program: typeof commander) {
         )
         .option(
             '--staticExternalsDescriptor <staticExternalsDescriptor>',
-            'relative to the output directory - a path to a json file which retrieves all external feature descriptors',
-            true
+            'relative to the output directory - a path to a json file which retrieves all external feature descriptors'
         )
         .option(
             '--includeExternalFeatures <includeExternalFeatures>',

--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -403,12 +403,15 @@ function loadExternalFeatures(target: 'web' | 'webworker' | 'electron-renderer',
     
     if(externalFeatures.length) {
         self.externalFeatures = externalFeatures;
-        const entryPaths = externalFeatures.map(({ name, envEntries }) => (envEntries[envName] ? envEntries[envName]['${target}'] : undefined)).filter(Boolean);
-        await ${target === 'webworker' ? 'importScripts' : loadScripts()}(entryPaths);
-
-        for (const { name } of externalFeatures) {
-            for (const loadedFeature of await featureLoader.getLoadedFeatures(name)) {
-                features.push(loadedFeature);
+        const filteredExternals = externalFeatures.filter(({name, envEntries}) => envEntries[envName] && envEntries[envName]['${target}']);
+        const entryPaths = filteredExternals.map(({ name, envEntries }) => (envEntries[envName]['${target}']));
+        if(filteredExternals.length) {
+            await ${target === 'webworker' ? 'importScripts' : loadScripts()}(entryPaths);
+    
+            for (const { name } of filteredExternals) {
+                for (const loadedFeature of await featureLoader.getLoadedFeatures(name)) {
+                    features.push(loadedFeature);
+                }
             }
         }
     }`;


### PR DESCRIPTION
Curretly we import an empty array if there are no external features for that environment but they exist