### PR TITLE
hotfix(scripts): fix public path resolution for fetching external features

### DIFF
--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -470,7 +470,7 @@ function getExternalFeaturesFromParent(externalFeaturesRoute: string) {
 
 function fetchExternalFeatures(externalFeaturesRoute: string) {
     return `const externalFeaturesRoute = '${externalFeaturesRoute}';
-            const path = publicPath + !publicPath.endsWith('/') ? '/' : '';
+            const path = publicPath + publicPath && !publicPath.endsWith('/') ? '/' : '';
             const normalizedExternalFeaturesRoute = !externalFeaturesRoute.startsWith('/') ? externalFeaturesRoute : externalFeaturesRoute.slice(1);
             return (await fetch(path + normalizedExternalFeaturesRoute)).json();
             `;


### PR DESCRIPTION
We didn't take into consideration that the publicPath may be an empty string, in which case we don't need to normalize it