### PR TITLE
infra: use our own virtual module loader instead of virtual-modules-plugin

### DIFF
--- a/packages/scripts/src/create-webpack-configs.ts
+++ b/packages/scripts/src/create-webpack-configs.ts
@@ -13,7 +13,7 @@ import {
 import type { getResolvedEnvironments } from './utils/environments';
 import type { IFeatureDefinition, IConfigDefinition, TopLevelConfigProvider } from './types';
 import { WebpackScriptAttributesPlugin } from './webpack-html-attributes-plugins';
-import { configLoader, virtualEntry, addVirtualModule } from './utils/generate-loader';
+import { configVirtualModuleLoader, virtualEntry, addVirtualModule } from './utils/generate-loader';
 export interface ICreateWebpackConfigsOptions {
     baseConfig?: Configuration;
     featureName?: string;
@@ -187,8 +187,8 @@ export function createWebpackConfig({
         }
     }
 
-    baseConfig.module?.rules?.push(configLoader());
-    const { plugins: basePlugins = [] } = baseConfig;
+    const { plugins: basePlugins = [], module: baseModule = {} } = baseConfig;
+    const { rules: baseRules = [] } = baseModule;
 
     return {
         ...baseConfig,
@@ -205,6 +205,10 @@ export function createWebpackConfig({
         },
         plugins: [...basePlugins, ...plugins],
         stats: 'errors-warnings',
+        module: {
+            ...baseModule,
+            rules: [...baseRules, configVirtualModuleLoader()],
+        },
     };
 }
 
@@ -247,9 +251,9 @@ export function createWebpackConfigForExternalFeature({
     };
     const externals: webpack.Configuration['externals'] = [externalFeatures];
     const { packageName, name, filePath } = feature;
-    baseConfig.module?.rules?.push(configLoader());
 
-    const { plugins: basePlugins = [] } = baseConfig;
+    const { plugins: basePlugins = [], module: baseModule = {} } = baseConfig;
+    const { rules: baseRules = [] } = baseModule;
 
     const userExternals = baseConfig.externals;
     if (userExternals) {
@@ -281,6 +285,10 @@ export function createWebpackConfigForExternalFeature({
             moduleIds: 'named',
         },
         stats: 'errors-warnings',
+        module: {
+            ...baseModule,
+            rules: [...baseRules, configVirtualModuleLoader()],
+        },
     };
     if (semverLessThan(webpack.version, '5.0.0')) {
         webpackConfig.output!.libraryTarget = 'var';

--- a/packages/scripts/src/utils/generate-loader.ts
+++ b/packages/scripts/src/utils/generate-loader.ts
@@ -19,26 +19,26 @@ interface WebpackLoaderContext {
     resourceQuery: string;
 }
 
-interface GenerateFileConfigurationOptions {
-    generate?: (ctx: WebpackLoaderContext) => string;
-}
-
 export default function loader(this: WebpackLoaderContext) {
     this.addContextDependency(this.rootContext);
     this._module.context = this.rootContext;
+
+    // The query comes with the ? - we need to slice it out
     const fileName = this.resourceQuery.slice(1);
     const generatedModule = virtualModules[fileName];
     if (generatedModule === undefined) {
         throw new Error(`No content was generated for virtual module ${this.resourceQuery}`);
     }
+
+    // The virtual module is no longer needed once it's loaded into the module system
+    // No reason to keep on holding it
     delete virtualModules.fileName;
     return generatedModule;
 }
 
-export function configLoader(options?: GenerateFileConfigurationOptions) {
+export function configVirtualModuleLoader() {
     return {
         loader: __filename,
-        options,
         resourceQuery: resourceMatcher,
     };
 }

--- a/packages/scripts/src/utils/generate-loader.ts
+++ b/packages/scripts/src/utils/generate-loader.ts
@@ -1,6 +1,6 @@
 import type webpack from 'webpack';
 
-const resourceMatcher = ;
+const resourceMatcher = /^\?generate-loader-(\w+)$/g;
 const virtualModules: Record<string, string> = {};
 interface WebpackLoaderContext {
     /**
@@ -40,7 +40,7 @@ export function configVirtualModuleLoader() {
         // Need to provide an options key to webpack, but we don't have any
         // So just pass an empty object
         options: {},
-        resourceQuery: /^\?generate-loader-(\w+)$/g,
+        resourceQuery: resourceMatcher,
     };
 }
 

--- a/packages/scripts/src/utils/generate-loader.ts
+++ b/packages/scripts/src/utils/generate-loader.ts
@@ -1,0 +1,39 @@
+import type webpack from 'webpack';
+
+const resourceMatcher = /^\?generate-loader-(\w+)$/g;
+
+interface WebpackLoaderContext {
+    /**
+     * Add a directory as dependency of the loader result.
+     * https://github.com/webpack/loader-runner/blob/6221befd031563e130f59d171e732950ee4402c6/lib/LoaderRunner.js#L305
+     */
+    addContextDependency(context: string): void;
+    /** https://github.com/webpack/webpack/blob/49890b77aae455b3204c17fdbed78eeb47bc1d98/lib/NormalModule.js#L472 */
+    getOptions(schema?: any): GenerateFileConfigurationOptions;
+    /**
+     * Hacky access to the Module object being loaded.
+     * https://github.com/TypeStrong/ts-loader/blob/e3a30c090a90ffc4f2bb21ed1d08ea98f361ac25/src/interfaces.ts#L346
+     */
+    _module: webpack.NormalModule;
+}
+
+interface GenerateFileConfigurationOptions {
+    generate: (ctx: WebpackLoaderContext) => string;
+}
+
+export default function loader(this: WebpackLoaderContext) {
+    const options = this.getOptions();
+    return options.generate(this);
+}
+
+export function configLoader(options: GenerateFileConfigurationOptions) {
+    return {
+        loader: __filename,
+        options,
+        resourceQuery: resourceMatcher,
+    };
+}
+
+export function virtualEntry(filename: string, id = 'entry') {
+    return `${filename}?generate-loader-${id}!=!${__filename}`;
+}

--- a/packages/scripts/src/utils/generate-loader.ts
+++ b/packages/scripts/src/utils/generate-loader.ts
@@ -8,8 +8,6 @@ interface WebpackLoaderContext {
      * https://github.com/webpack/loader-runner/blob/6221befd031563e130f59d171e732950ee4402c6/lib/LoaderRunner.js#L305
      */
     addContextDependency(context: string): void;
-    /** https://github.com/webpack/webpack/blob/49890b77aae455b3204c17fdbed78eeb47bc1d98/lib/NormalModule.js#L472 */
-    getOptions(schema?: any): GenerateFileConfigurationOptions;
     /**
      * Hacky access to the Module object being loaded.
      * https://github.com/TypeStrong/ts-loader/blob/e3a30c090a90ffc4f2bb21ed1d08ea98f361ac25/src/interfaces.ts#L346

--- a/packages/scripts/src/utils/generate-loader.ts
+++ b/packages/scripts/src/utils/generate-loader.ts
@@ -1,6 +1,6 @@
 import type webpack from 'webpack';
 
-const resourceMatcher = /^\?generate-loader-(\w+)$/g;
+const resourceMatcher = ;
 const virtualModules: Record<string, string> = {};
 interface WebpackLoaderContext {
     /**
@@ -37,7 +37,10 @@ export default function loader(this: WebpackLoaderContext) {
 export function configVirtualModuleLoader() {
     return {
         loader: __filename,
-        resourceQuery: resourceMatcher,
+        // Need to provide an options key to webpack, but we don't have any
+        // So just pass an empty object
+        options: {},
+        resourceQuery: /^\?generate-loader-(\w+)$/g,
     };
 }
 

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -45,7 +45,7 @@ describe('Application', function () {
 
         it(`supports building features with a single fixture`, async () => {
             const app = new Application({ basePath: engineFeatureFixturePath });
-            await app.build({ mode: 'development' });
+            await app.build();
             disposables.add(() => app.clean());
 
             expect(fs.directoryExistsSync(app.outputPath), 'has dist folder').to.equal(true);

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -45,7 +45,7 @@ describe('Application', function () {
 
         it(`supports building features with a single fixture`, async () => {
             const app = new Application({ basePath: engineFeatureFixturePath });
-            await app.build();
+            await app.build({ mode: 'development' });
             disposables.add(() => app.clean());
 
             expect(fs.directoryExistsSync(app.outputPath), 'has dist folder').to.equal(true);
@@ -53,7 +53,7 @@ describe('Application', function () {
 
         it(`allows building feature with given favicon`, async () => {
             const app = new Application({ basePath: engineFeatureFixturePath });
-            await app.build({ favicon: 'assets/favicon.ico' });
+            await app.build({ favicon: 'assets/favicon.ico', mode: 'development' });
             disposables.add(() => app.clean());
             expect(fs.directoryExistsSync(app.outputPath), 'has dist folder').to.equal(true);
             const contents = fs.readdirSync(app.outputPath);

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -53,7 +53,7 @@ describe('Application', function () {
 
         it(`allows building feature with given favicon`, async () => {
             const app = new Application({ basePath: engineFeatureFixturePath });
-            await app.build({ favicon: 'assets/favicon.ico', mode: 'development' });
+            await app.build({ favicon: 'assets/favicon.ico' });
             disposables.add(() => app.clean());
             expect(fs.directoryExistsSync(app.outputPath), 'has dist folder').to.equal(true);
             const contents = fs.readdirSync(app.outputPath);


### PR DESCRIPTION
Born from an issue with multiple builds in webpack 5