### PR TITLE
fix: set main-dashboard.html as index file for engineer dashboards

### DIFF
--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -23,7 +23,8 @@ import { buildFeatureLinks } from '../feature-dependency-graph';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const webpackDevMiddleware = require('webpack-dev-middleware') as (
-    compiler: webpack.MultiCompiler
+    compiler: webpack.MultiCompiler,
+    options?: { index?: string }
 ) => WebpackDevMiddleware;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const webpackHotMiddleware = require('webpack-hot-middleware') as (
@@ -271,7 +272,7 @@ devServerFeature.setup(
              */
             const engineerCompilers = webpack([...engineerWebpackConfigs]);
             if (engineerCompilers.compilers.length > 0) {
-                const engineerDevMiddleware = webpackDevMiddleware(engineerCompilers);
+                const engineerDevMiddleware = webpackDevMiddleware(engineerCompilers, { index: 'main-dashboard.html' });
                 disposables.add(
                     () => new Promise<void>((res) => engineerDevMiddleware.close(res))
                 );

--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -272,6 +272,9 @@ devServerFeature.setup(
              */
             const engineerCompilers = webpack([...engineerWebpackConfigs]);
             if (engineerCompilers.compilers.length > 0) {
+                // This assumes we have only one engineer config - for the dashboard
+                // If we decide to create more engineers one day we might need to rethink the index file
+                // In any case it's a fallback, full paths should still work as usual
                 const engineerDevMiddleware = webpackDevMiddleware(engineerCompilers, { index: 'main-dashboard.html' });
                 disposables.add(
                     () => new Promise<void>((res) => engineerDevMiddleware.close(res))

--- a/packages/engineer/test/gui.unit.ts
+++ b/packages/engineer/test/gui.unit.ts
@@ -53,6 +53,19 @@ describe('engineer:gui', function () {
             config: { port },
         } = await setup({ basePath: engineFeatureFixturePath });
 
+        const page = await loadPage(`http://localhost:${port}/`);
+
+        const text = await page.evaluate(() => document.body.textContent!.trim());
+
+        expect(text).to.include('Feature');
+        expect(text).to.include('Config');
+    });
+
+    it('should allow visit of dashboard gui through full path', async () => {
+        const {
+            config: { port },
+        } = await setup({ basePath: engineFeatureFixturePath });
+
         const page = await loadPage(`http://localhost:${port}/main-dashboard.html?feature=engineer/gui`);
 
         const text = await page.evaluate(() => document.body.textContent!.trim());


### PR DESCRIPTION
The issue with not being able to see the project from the root of the monorepo is because we have the dashboard both as the actual dashboard and as a regular feature in the project, so we have 2 middleware serving main-dashboard.html
because the application middleware is registered first it catches the request and serves the one without the default feature being set, so we need to pass it manually.

It can basically happen with every application that serves a main-dashboard environment.

The way to resolve it is to resolve the conflict in the URL which I see several options
1. Namespace the middleware
2. Serve from different servers
3. Assume that our dashboard is the default dashboard and add it as an index - therefor solving the URL conflict. 