### PR TITLE
refactor: better virtual-modules with !=!

### DIFF
--- a/packages/engineer/package.json
+++ b/packages/engineer/package.json
@@ -26,8 +26,7 @@
     "open": "^8.2.0",
     "socket.io": "^4.1.2",
     "webpack-dev-middleware": "^5.0.0",
-    "webpack-hot-middleware": "^2.25.0",
-    "webpack-virtual-modules": "^0.4.3"
+    "webpack-hot-middleware": "^2.25.0"
   },
   "files": [
     "bin",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -25,8 +25,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "socket.io": "^4.1.2",
-    "type-fest": "^1.2.0",
-    "webpack-virtual-modules": "^0.4.3"
+    "type-fest": "^1.2.0"
   },
   "files": [
     "dist",

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -16,3 +16,4 @@ export * from './types';
 export * from './utils';
 export * from './ws-environment';
 export * from './webpack-html-attributes-plugins';
+export { createVirtualEntries, VirtualModulesLoaderOptions } from './virtual-modules-loader';

--- a/packages/scripts/src/virtual-modules-loader.ts
+++ b/packages/scripts/src/virtual-modules-loader.ts
@@ -1,0 +1,39 @@
+import type webpack from 'webpack';
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+export interface VirtualModulesLoaderOptions {
+    [fileName: string]: string;
+}
+
+const virtualModulesLoader: webpack.LoaderDefinition = function () {
+    const options = this.getOptions() as VirtualModulesLoaderOptions;
+    const match = /^\?id=(.*)$/.exec(this.resourceQuery);
+    if (!match) {
+        throw new Error(`invalid resourceQuery: ${this.resourceQuery}`);
+    }
+    const fileName = match[1]!;
+    if (!options[fileName]) {
+        throw new Error(`missing generator for: ${fileName}`);
+    }
+    return options[fileName]!;
+};
+
+export default virtualModulesLoader;
+
+export function createVirtualEntries(options: VirtualModulesLoaderOptions) {
+    const entries: webpack.EntryObject = {};
+    for (const entry of Object.keys(options)) {
+        entries[entry] = `${entry}!=!${__filename}?id=${entry}`;
+    }
+    return {
+        entries,
+        loaderRule: {
+            loader: __filename,
+            options,
+            test(entry: string) {
+                return hasOwnProperty.call(options, entry);
+            },
+        },
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7416,11 +7416,6 @@ webpack-sources@^2.3.0:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack-virtual-modules@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.3.tgz#cd597c6d51d5a5ecb473eea1983a58fa8a17ded9"
-  integrity sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==
-
 webpack@^5.39.0:
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.39.0.tgz#37d6899f1f40c31d5901abc0f39bc8cc7224138c"


### PR DESCRIPTION
webpack-virtual-modules doesn't work well with webpack@5.
replaced it with custom loader solution that uses !=! to represent new virtual entry module, getting their contents from options.