### PR TITLE
fix: avoid waitUntilValid, as it triggers logging

### DIFF
--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -230,9 +230,7 @@ devServerFeature.setup(
                 disposables.add(() => new Promise<void>((res) => devMiddleware.close(res)));
                 app.use(devMiddleware);
                 compilationPromises.push(
-                    new Promise<void>((resolve) => {
-                        devMiddleware.waitUntilValid(() => resolve());
-                    })
+                    new Promise<void>((resolve) => compiler.hooks.done.tap('engineer', () => resolve()))
                 );
                 if (webpackHot) {
                     const hotMiddleware = webpackHotMiddleware(compiler);
@@ -282,9 +280,9 @@ devServerFeature.setup(
                 disposables.add(() => new Promise<void>((res) => engineerDevMiddleware.close(res)));
                 app.use(engineerDevMiddleware);
                 compilationPromises.push(
-                    new Promise<void>((resolve) => {
-                        engineerDevMiddleware.waitUntilValid(() => resolve());
-                    })
+                    new Promise<void>((resolve) =>
+                        engineerCompilers.hooks.done.tap('engineer dashboard', () => resolve())
+                    )
                 );
             }
 


### PR DESCRIPTION
instead, directly wait for the top compiler to be done, which is only called once.

Fixes messages of "wait until bundle finished" printing in basically every flow.