### PR TITLE
infra(webpack): use native asset modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,16 +19,8 @@ module.exports = {
                 loader: '@ts-tools/webpack-loader',
             },
             {
-                test: /\.css$/,
-                exclude: /\.st\.css$/,
-                use: ['style-loader', 'css-loader'],
-            },
-            {
                 test: /\.(png|jpg|gif|svg)$/i,
-                loader: 'url-loader',
-                options: {
-                    limit: 2048,
-                },
+                type: 'asset',
             },
         ],
     },


### PR DESCRIPTION
and remove css-loader usage, as no css is now used within repo (and it isn't even specified as a direct dep; got it from mocha-play)