### PR TITLE
feat(scripts): featureDiscoveryRoot via config file

### DIFF
--- a/packages/engineer/src/application-proxy-service.ts
+++ b/packages/engineer/src/application-proxy-service.ts
@@ -35,13 +35,14 @@ export class TargetApplication extends Application {
 
     public getFeatures(
         singleFeature?: boolean,
-        featureName?: string
+        featureName?: string,
+        featureDiscoveryRoot?: string
     ): {
         packages: INpmPackage[];
         features: Map<string, IFeatureDefinition>;
         configurations: SetMultiMap<string, IConfigDefinition>;
     } {
-        const { features, configurations, packages } = super.analyzeFeatures();
+        const { features, configurations, packages } = super.analyzeFeatures(featureDiscoveryRoot);
         if (singleFeature && featureName) {
             this.filterByFeatureName(features, featureName);
         }

--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -5,7 +5,7 @@
  * This configuration can (and should) be written as a `.ts` file.
  */
 
-import type {Command} from 'commander';
+import type { Command } from 'commander';
 import { resolve } from 'path';
 import open from 'open';
 import fs from '@file-services/node';
@@ -186,10 +186,11 @@ export function buildCommand(program: Command) {
                 preRequire(pathsToRequire, basePath);
                 const favicon = faviconPath ? resolve(basePath, faviconPath) : undefined;
                 const outputPath = resolve(outDir);
-                const app = new Application({ basePath, outputPath, featureDiscoveryRoot });
+                const app = new Application({ basePath, outputPath });
                 const stats = await app.build({
                     featureName,
                     configName,
+                    featureDiscoveryRoot,
                     publicPath,
                     mode,
                     singleFeature,

--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -73,13 +73,13 @@ devServerFeature.setup(
             externalFeatureDefinitions: providedExternalDefinitions,
             externalFeaturesPath: providedExternalFeaturesPath,
             serveExternalFeaturesPath = true,
-            featureDiscoveryRoot,
+            featureDiscoveryRoot: providedFeatureDiscoveryRoot,
             socketServerOptions = {},
             webpackConfigPath,
             externalFeaturesRoute,
             webpackHot = false,
         } = devServerConfig;
-        const application = new TargetApplication({ basePath, outputPath, featureDiscoveryRoot });
+        const application = new TargetApplication({ basePath, outputPath });
         const disposables = createDisposables();
 
         onDispose(disposables.dispose);
@@ -94,6 +94,7 @@ devServerFeature.setup(
                 socketServerOptions: configServerOptions = {},
                 externalFeaturesBasePath: configExternalFeaturesPath,
                 serveStatic = [],
+                featureDiscoveryRoot,
             } = engineConfig ?? {};
             if (require) {
                 await application.importModules(require);
@@ -130,7 +131,11 @@ devServerFeature.setup(
             // So we launch with a basehost and upgrade to a wshost
             attachWSHost(socketServer, devServerEnv.env, communication);
 
-            const { features, configurations, packages } = application.getFeatures(singleFeature, featureName);
+            const { features, configurations, packages } = application.getFeatures(
+                singleFeature,
+                featureName,
+                providedFeatureDiscoveryRoot ?? featureDiscoveryRoot
+            );
             const externalFeatures = getExternalFeaturesMetadata(fixedExternalFeatureDefinitions, externalFeaturesPath);
 
             //Node environment manager, need to add self to the topology, I thing starting the server and the NEM should happen in the setup and not in the run

--- a/packages/scripts/src/analyze-feature.ts
+++ b/packages/scripts/src/analyze-feature.ts
@@ -32,14 +32,14 @@ interface IPackageDescriptor {
 
 const featureRoots = ['.', 'src', 'feature', 'fixtures'] as const;
 
-export function loadFeaturesFromPackages(npmPackages: INpmPackage[], fs: IFileSystemSync, rootOwnFeaturesDir = '.') {
+export function loadFeaturesFromPackages(npmPackages: INpmPackage[], fs: IFileSystemSync, featureDiscoveryRoot = '.') {
     const ownFeatureFilePaths = new Set<string>();
     const ownFeatureDirectoryPaths = new Set<string>();
 
     // pick up own feature files in provided npm packages
     for (const { directoryPath } of npmPackages) {
         for (const rootName of featureRoots) {
-            const rootPath = fs.join(directoryPath, rootOwnFeaturesDir, rootName);
+            const rootPath = fs.join(directoryPath, featureDiscoveryRoot, rootName);
             if (!fs.directoryExistsSync(rootPath)) {
                 continue;
             }

--- a/packages/scripts/src/load-node-environment.ts
+++ b/packages/scripts/src/load-node-environment.ts
@@ -4,10 +4,10 @@ import { loadFeaturesFromPackages } from './analyze-feature';
 import type { IConfigDefinition } from './types';
 import { resolvePackages } from './utils/resolve-packages';
 
-export function readFeatures(fs: IFileSystem, basePath: string, featuresDirectory?: string) {
+export function readFeatures(fs: IFileSystem, basePath: string, featureDiscoveryRoot?: string) {
     const packages = resolvePackages(basePath);
 
-    return loadFeaturesFromPackages(packages, fs, featuresDirectory);
+    return loadFeaturesFromPackages(packages, fs, featureDiscoveryRoot);
 }
 
 export function evaluateConfig(

--- a/packages/scripts/src/remote-node-entry.ts
+++ b/packages/scripts/src/remote-node-entry.ts
@@ -6,10 +6,10 @@ const isFirstArgumentPath = process.argv[1]!.startsWith('-');
 
 const path = isFirstArgumentPath ? process.cwd() : process.argv[1]!;
 
-const { preferredPort, featureDiscoveryRoot } = parseCliArguments(process.argv.slice(isFirstArgumentPath ? 2 : 1));
+const { preferredPort } = parseCliArguments(process.argv.slice(isFirstArgumentPath ? 2 : 1));
 
 const basePath = resolve(path);
-const app = new Application({ basePath, featureDiscoveryRoot: featureDiscoveryRoot as string });
+const app = new Application({ basePath });
 const port = preferredPort ? parseInt(preferredPort as string, 10) : undefined;
 app.remote({ port }).catch((e) => {
     console.error(e);

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -291,6 +291,7 @@ export interface IExternalDefinition {
 
 export interface EngineConfig {
     require?: string[];
+    featureDiscoveryRoot?: string;
     featuresDirectory?: string;
     featureTemplatesFolder?: string;
     featureFolderNameTemplate?: string;


### PR DESCRIPTION
allows specifying featureDiscoveryRoot in `engine.config.js`.