### PR TITLE
infra: simplify lint setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,3 @@ cjs
 esm
 umd
 dist
-_wcs

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,8 +22,7 @@
     {
       "files": ["*.ts", "*.tsx"],
       "parserOptions": {
-        "project": ["packages/*/{src,test}/tsconfig.json", "examples/*/tsconfig.json"],
-        "EXPERIMENTAL_useSourceOfProjectReferenceRedirect": true
+        "project": "./tsconfig.test.json"
       },
       "extends": [
         "plugin:@typescript-eslint/recommended",

--- a/examples/file-server/tsconfig.json
+++ b/examples/file-server/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "types": ["mocha", "node"]
+    "outDir": "./dist"
   },
   "references": [{ "path": "../../packages/core/src" }, { "path": "../../packages/test-kit/src" }]
 }

--- a/examples/multi-env/tsconfig.json
+++ b/examples/multi-env/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "types": ["mocha", "node"]
+    "outDir": "./dist"
   },
   "references": [{ "path": "../../packages/core/src" }, { "path": "../../packages/test-kit/src" }]
 }

--- a/examples/node-only/tsconfig.json
+++ b/examples/node-only/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "types": ["mocha", "node"]
+    "outDir": "./dist"
   },
   "references": [
     { "path": "../../packages/core/src" },

--- a/examples/preload/tsconfig.json
+++ b/examples/preload/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "types": ["mocha", "node"]
+    "outDir": "./dist"
   },
   "references": [
     { "path": "../../packages/core/src" },

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "types": ["mocha", "node"]
+    "outDir": "./dist"
   },
   "references": [{ "path": "../../packages/core/src" }]
 }

--- a/examples/reloaded-iframe/tsconfig.json
+++ b/examples/reloaded-iframe/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "types": ["mocha", "node"]
+    "outDir": "./dist"
   },
   "references": [{ "path": "../../packages/core/src" }, { "path": "../../packages/test-kit/src" }]
 }

--- a/packages/core-node/test/tsconfig.json
+++ b/packages/core-node/test/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "outDir": "../dist/test"
   },
   "references": [
     {

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "outDir": "../dist/test"
   },
   "references": [
     {

--- a/packages/dashboard/test/tsconfig.json
+++ b/packages/dashboard/test/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "outDir": "../dist/test"
   },
   "references": [
     {

--- a/packages/engineer/test/tsconfig.json
+++ b/packages/engineer/test/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "outDir": "../dist/test"
   },
   "references": [
     {

--- a/packages/scripts/test/tsconfig.json
+++ b/packages/scripts/test/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "outDir": "../dist/test"
   },
   "references": [
     {

--- a/packages/test-kit/src/tsconfig.json
+++ b/packages/test-kit/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "../dist",
-    "types": ["mocha", "node"]
+    "outDir": "../dist"
   },
   "references": [
     {

--- a/packages/test-kit/test/tsconfig.json
+++ b/packages/test-kit/test/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "outDir": "../dist/test",
-    "types": ["mocha", "node"]
+    "outDir": "../dist/test"
   },
   "references": [
     {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["mocha", "node"]
+  }
+}


### PR DESCRIPTION
typescript-eslint's experimental project ref support is not working great.
by using a single commit test tsconfig, lint time drops significantly. we do have to build first now, in order to lint.