### PR TITLE
fix(com): fix iframe initializer handling of src parameter

### DIFF
--- a/packages/core/src/com/initializers/iframe.ts
+++ b/packages/core/src/com/initializers/iframe.ts
@@ -11,7 +11,7 @@ export interface IIframeInitializerOptions {
     managed?: boolean;
 }
 
-export interface IframeInitializerOptions extends InitializerOptions, IIframeInitializerOptions { }
+export interface IframeInitializerOptions extends InitializerOptions, IIframeInitializerOptions {}
 
 export async function iframeInitializer({
     communication,
@@ -30,7 +30,7 @@ export function deferredIframeInitializer({ communication: com, env: { env, endp
     initialize: (options: IIframeInitializerOptions) => Promise<string>;
 } {
     const instanceId = com.getEnvironmentInstanceId(env, endpointType);
-    const envReadyPromise = com.envReady(instanceId)
+    const envReadyPromise = com.envReady(instanceId);
     return {
         id: instanceId,
         initialize: ({ managed, iframeElement, hashParams, src }: IIframeInitializerOptions) => {
@@ -40,19 +40,19 @@ export function deferredIframeInitializer({ communication: com, env: { env, endp
                 envReadyPromise,
                 instanceId,
                 src:
-                    src ?? managed
+                    src || managed
                         ? defaultHtmlSourceFactory(env, publicPath, hashParams)
                         : defaultSourceFactory(env, publicPath),
             };
             return managed
                 ? startManagedIframe({
-                    ...baseStartIframeParams,
-                    iframe: iframeElement,
-                })
+                      ...baseStartIframeParams,
+                      iframe: iframeElement,
+                  })
                 : startIframe({
-                    ...baseStartIframeParams,
-                    host: iframeElement,
-                });
+                      ...baseStartIframeParams,
+                      host: iframeElement,
+                  });
         },
     };
 }

--- a/packages/core/src/com/initializers/iframe.ts
+++ b/packages/core/src/com/initializers/iframe.ts
@@ -40,7 +40,7 @@ export function deferredIframeInitializer({ communication: com, env: { env, endp
                 envReadyPromise,
                 instanceId,
                 src:
-                    src || managed
+                    src ?? (managed ? ... )
                         ? defaultHtmlSourceFactory(env, publicPath, hashParams)
                         : defaultSourceFactory(env, publicPath),
             };

--- a/packages/core/src/com/initializers/iframe.ts
+++ b/packages/core/src/com/initializers/iframe.ts
@@ -40,9 +40,10 @@ export function deferredIframeInitializer({ communication: com, env: { env, endp
                 envReadyPromise,
                 instanceId,
                 src:
-                    src ?? (managed ? ... )
+                    src ??
+                    (managed
                         ? defaultHtmlSourceFactory(env, publicPath, hashParams)
-                        : defaultSourceFactory(env, publicPath),
+                        : defaultSourceFactory(env, publicPath)),
             };
             return managed
                 ? startManagedIframe({


### PR DESCRIPTION
The previous version never used the src that was passed to it, only as a condition. See the compiled version:
![image](https://user-images.githubusercontent.com/16363487/130409079-3dcec0eb-cb5b-42d2-ba91-a3a6f9458baa.png)
