### PR TITLE
hotfix: not handling custom config routes properly

### DIFF
--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -410,7 +410,9 @@ function addConfigsEventListenerForParentEnvironments(publicConfigsRoute: string
         const configsEventListener = async ({ data: { id, envName }, source }) => {
             if(source && id === '${publicConfigsRoute}') {
                 if(!fetchedConfigs[envName]) {
-                    const config = await (await fetch('configs/' + configName + '?env=' + envName + '&feature=' + featureName)).json();
+                    const config = await (await fetch('${normalizeRoute(
+                        publicConfigsRoute
+                    )}/' + configName + '?env=' + envName + '&feature=' + featureName)).json();
                     fetchedConfigs[envName] = config;
                 }
                 source.postMessage({

--- a/test-fixtures/with-iframe/feature/x.feature.ts
+++ b/test-fixtures/with-iframe/feature/x.feature.ts
@@ -1,0 +1,13 @@
+import { COM, Environment, Feature, Service } from '@wixc3/engine-core';
+export const mainEnv = new Environment('main', 'window', 'single');
+export const iframeEnv = new Environment('iframe', 'iframe', 'single');
+
+export default new Feature({
+    id: 'XTestFeature',
+    api: {
+        echoService: Service.withType<{ echo: (message: string) => void }>()
+            .defineEntity(iframeEnv)
+            .allowRemoteAccess(),
+    },
+    dependencies: [COM],
+});

--- a/test-fixtures/with-iframe/feature/x.iframe.env.ts
+++ b/test-fixtures/with-iframe/feature/x.iframe.env.ts
@@ -1,0 +1,12 @@
+import { iframeEnv } from './x.feature';
+import sampleFeature from './x.feature';
+
+sampleFeature.setup(iframeEnv, ({}) => {
+    return {
+        echoService: {
+            echo: (message) => {
+                document.body.appendChild(document.createTextNode(message));
+            },
+        },
+    };
+});

--- a/test-fixtures/with-iframe/feature/x.main.env.ts
+++ b/test-fixtures/with-iframe/feature/x.main.env.ts
@@ -1,0 +1,18 @@
+import { iframeInitializer } from '@wixc3/engine-core';
+import { mainEnv, iframeEnv } from './x.feature';
+import sampleFeature from './x.feature';
+
+sampleFeature.setup(mainEnv, ({ run, echoService }, { COM: { communication } }) => {
+    const myFrame = document.createElement('iframe');
+    myFrame.id = 'iframe';
+    document.body.append(myFrame);
+
+    run(async () => {
+        await iframeInitializer({
+            communication,
+            env: iframeEnv,
+            iframeElement: myFrame,
+        });
+        await echoService.echo('echo');
+    });
+});

--- a/test-fixtures/with-iframe/package.json
+++ b/test-fixtures/with-iframe/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/with-iframe",
+  "version": "21.1.2",
+  "private": true
+}

--- a/test-fixtures/with-iframe/tsconfig.json
+++ b/test-fixtures/with-iframe/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "references": [
+    {
+      "path": "../../packages/core/src"
+    },
+    {
+      "path": "../../packages/core-node/src"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,7 @@
     { "path": "./test-fixtures/static-application-external" },
     { "path": "./test-fixtures/static-base-web-application" },
     { "path": "./test-fixtures/using-config" },
+    { "path": "./test-fixtures/with-iframe" },
     { "path": "./test-fixtures/workspace" }
   ]
 }


### PR DESCRIPTION
after the minor refactor with the config fetching, I accidentally hard-coded the word 'configs' rather then using the `publicConfigsRoute` variable.

Added a test