### PR TITLE
infra: IDE-friendly typescript-eslint refs workaround

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,7 @@
     {
       "files": ["*.ts", "*.tsx"],
       "parserOptions": {
-        "project": "./tsconfig.test.json"
+        "project": "./tsconfig.lint.json"
       },
       "extends": [
         "plugin:@typescript-eslint/recommended",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint . -f codeframe",
     "prestart": "yarn build",
     "start": "engineer start --featureDiscoveryRoot dist",
-    "pretest": "yarn build && yarn lint",
+    "pretest": "yarn lint && yarn build",
     "test": "yarn test:unit",
     "test:unit": "lerna run test --stream --concurrency=1",
     "prettify": "npx prettier . --write"

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.test.json",
+  "compilerOptions": {
+    "paths": {
+      "@wixc3/engine-*": ["./packages/*/src"],
+      "@wixc3/*": ["./packages/*/src"],
+      "@wixc3/engine-dashboard/dist/*": ["./packages/dashboard/src/*"],
+      "@wixc3/engine-test-kit/dist/*": ["./packages/test-kit/src/*"],
+      "@wixc3/engineer/dist/*": ["./packages/engineer/src/*"],
+      "@fixture/*-feature": ["./test-fixtures/*/src"],
+      "@fixture/static-base-web-application-feature/dist/*": ["./test-fixtures/static-base-web-application/*"],
+      "@fixture/3rd-party/dist/*": ["./test-fixtures/3rd-party/*"],
+      "@fixture/engine-multi-node/dist/*": ["./test-fixtures/multi-node/*"],
+      "@fixture/engine-multi-socket-node/dist/*": ["./test-fixtures/multi-socket-node/*"]
+    }
+  }
+}


### PR DESCRIPTION
`typescript-eslint` gets OOM when we're using it's project refs support.

using `compilerOptions.paths` just for the lint flow allows us to get a nicer IDE behavior without requiring us to build in order to lint.