### PR TITLE
feat(with-feature): providePageErrorsHandler

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -8,6 +8,7 @@ import { ensureTracePath } from './utils';
 import type { IExecutableApplication } from './types';
 import { hookPageConsole } from './hook-page-console';
 import type { PerformanceMetrics } from '@wixc3/engine-runtime-node';
+import { type } from 'os';
 
 const cliEntry = require.resolve('@wixc3/engineer/bin/engineer');
 
@@ -106,6 +107,8 @@ export interface Tracing {
     name?: string;
 }
 
+export type PageErrorsHandler = (pageErrors: Error[]) => void;
+
 let browser: playwright.Browser | undefined = undefined;
 let featureUrl = '';
 let executableApp: IExecutableApplication;
@@ -194,13 +197,29 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
         browserContexts.clear();
     });
 
-    afterEach('verify no page errors', () => {
+    const defaultErrorHandler = () => {
         if (capturedErrors.length) {
             const errorsText = capturedErrors.join('\n');
             capturedErrors.length = 0;
             throw new Error(`there were uncaught page errors during the test:\n${errorsText}`);
         }
+    };
+
+    const errorHandlers: Array<(pageErrors: Error[]) => void> = [];
+
+    beforeEach(() => {
+        errorHandlers.push(defaultErrorHandler);
     });
+
+    afterEach('verify page errors', () => {
+        errorHandlers[errorHandlers.length - 1]!(capturedErrors);
+        errorHandlers.length = 0;
+        capturedErrors.length = 0;
+    });
+
+    const providePageErrorsHandler = (cb: PageErrorsHandler) => {
+        errorHandlers.push(cb);
+    };
 
     return {
         async getLoadedFeature(
@@ -313,7 +332,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                 return measures;
             }
 
-            return { page: featurePage, response, getMetrics };
+            return { page: featurePage, response, getMetrics, providePageErrorsHandler };
         },
     };
 }

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -8,7 +8,6 @@ import { ensureTracePath } from './utils';
 import type { IExecutableApplication } from './types';
 import { hookPageConsole } from './hook-page-console';
 import type { PerformanceMetrics } from '@wixc3/engine-runtime-node';
-import { type } from 'os';
 
 const cliEntry = require.resolve('@wixc3/engineer/bin/engineer');
 


### PR DESCRIPTION
After a discussion with @RomanYarik we came up with this solution of having the option to override the default behavior of not allowing any uncaught errors on with a custom handler.