### PR TITLE
fix(com): forwarding listen messages properly

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -474,8 +474,8 @@ export class Communication {
             }
         } else if (message.type === 'unlisten') {
             await this.forwardUnlisten(message);
-        } else {
-            await this.forwardListenMessage(message as ListenMessage);
+        } else if (message.type === 'listen') {
+            await this.forwardListenMessage(message);
         }
     }
 


### PR DESCRIPTION
in cases where the forwarded message is a dispose message, we want to ignore it, since the engine initiates the disposing call to other environments once it receives the dispose message for itself.

this caused dispose messages to be handled as listen calls