### PR TITLE
fix(core-node): handle process disconnection

### DIFF
--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -447,7 +447,6 @@ describe('Application', function () {
         });
 
         it('loads external features', async () => {
-            this.timeout(20_000);
             const externalFeatureName = 'application-external';
             const { name } = fs.readJsonFileSync(join(applicationExternalFixturePath, 'package.json')) as {
                 name: string;
@@ -517,7 +516,7 @@ describe('Application', function () {
                 },
                 { timeout: 5_000 }
             );
-        });
+        }).timeout(20_000);
 
         it('loads external features after static build', async () => {
             const externalFeatureName = 'static-application-external/application-external';

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -447,6 +447,7 @@ describe('Application', function () {
         });
 
         it('loads external features', async () => {
+            this.timeout(20_000);
             const externalFeatureName = 'application-external';
             const { name } = fs.readJsonFileSync(join(applicationExternalFixturePath, 'package.json')) as {
                 name: string;

--- a/packages/test-kit/src/detached-app.ts
+++ b/packages/test-kit/src/detached-app.ts
@@ -22,13 +22,12 @@ export class DetachedApp implements IExecutableApplication {
             args.push(this.featureDiscoveryRoot);
         }
 
-        const engineStartProcess = fork(this.cliEntry, args, {
+        this.engineStartProcess = fork(this.cliEntry, args, {
             stdio: 'inherit',
             cwd: this.basePath,
             execArgv,
         });
 
-        this.engineStartProcess = engineStartProcess;
         const { port } = await this.waitForProcessMessage<IPortMessage>('port-request', (p) =>
             p.send({ id: 'port-request' })
         );


### PR DESCRIPTION
currently, if process is closed, we still try to send messages to it.
fixing that in a similar manner to what was done in the socket server socket disconnection handling