### PR TITLE
feat(scripts): return the build data from build command

### DIFF
--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -181,7 +181,7 @@ export function buildCommand(program: Command) {
                 const favicon = faviconPath ? resolve(basePath, faviconPath) : undefined;
                 const outputPath = resolve(outDir);
                 const app = new Application({ basePath, outputPath });
-                const stats = await app.build({
+                const { stats } = await app.build({
                     featureName,
                     configName,
                     featureDiscoveryRoot,

--- a/packages/scripts/src/application.ts
+++ b/packages/scripts/src/application.ts
@@ -174,7 +174,12 @@ export class Application {
         externalFeaturesBasePath,
         externalFeatureDefinitions: providedExternalFeatureDefinitions = [],
         featureDiscoveryRoot: providedFeatureDiscoveryRoot,
-    }: IBuildCommandOptions = {}): Promise<WebpackMultiStats> {
+    }: IBuildCommandOptions = {}): Promise<{
+        stats: WebpackMultiStats;
+        features: Map<string, IFeatureDefinition>;
+        configurations: SetMultiMap<string, IConfigDefinition>;
+        resolvedEnvironments: ReturnType<typeof getResolvedEnvironments>;
+    }> {
         const { config, path: configPath } = await this.getEngineConfig();
         const {
             require,
@@ -308,7 +313,7 @@ export class Application {
             pathToSources: sourceRoot,
         });
 
-        return stats;
+        return { stats, features, configurations, resolvedEnvironments };
     }
 
     public async run(runOptions: IRunCommandOptions = {}) {


### PR DESCRIPTION
Currently build command only returns the compilation stats. modifying it to also return the features, configurations and resolved environments for that build.

This allows also fixing the issue with entries which should be filtered out, appears in the electron entrypoint