### PR TITLE
fix(com): properly forwarding errors

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -441,24 +441,33 @@ export class Communication {
 
     private async forwardMessage(message: Message, env: EnvironmentRecord): Promise<void> {
         if (message.type === 'call') {
-            const forwardResponse = await this.callMethod(
-                env.id,
-                message.data.api,
-                message.data.method,
-                message.data.args,
-                message.origin,
-                {}
-            );
-
             if (message.callbackId) {
-                this.sendTo(message.from, {
-                    from: message.to,
-                    type: 'callback',
-                    to: message.from,
-                    data: forwardResponse,
-                    callbackId: message.callbackId,
-                    origin: message.to,
-                });
+                try {
+                    this.sendTo(message.from, {
+                        from: message.to,
+                        type: 'callback',
+                        to: message.from,
+                        data: await this.callMethod(
+                            env.id,
+                            message.data.api,
+                            message.data.method,
+                            message.data.args,
+                            message.origin,
+                            {}
+                        ),
+                        callbackId: message.callbackId,
+                        origin: message.to,
+                    });
+                } catch (error) {
+                    this.sendTo(message.from, {
+                        from: message.to,
+                        type: 'callback',
+                        to: message.from,
+                        error: serializeError(error),
+                        callbackId: message.callbackId,
+                        origin: message.to,
+                    });
+                }
             }
         } else if (message.type === 'callback') {
             if (message.callbackId) {
@@ -616,12 +625,12 @@ export class Communication {
         res: () => void,
         rej: () => void
     ) {
-        this.sendTo(envId, message);
         if (callbackId) {
             this.createCallbackRecord(message, callbackId, res, rej);
         } else {
             res();
         }
+        this.sendTo(envId, message);
     }
     private sendTo(envId: string, message: Message): void {
         if (this.pendingEnvs.get(envId)) {

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -388,12 +388,16 @@ describe('Communication', () => {
         // create a service at 4
         const echoService = {
             echo: (text: string) => `hello ${text}`,
+            fail: (): string => {
+                throw new Error('fail');
+            },
         };
         com4.registerAPI({ id: 'service' }, echoService);
 
         // call it from 2
         const apiProxy = com2.apiProxy<typeof echoService>({ id: 'com4' }, { id: 'service' });
         expect(await apiProxy.echo('name')).to.eq('hello name');
+        await expect(apiProxy.fail()).to.be.rejectedWith('fail');
     });
 });
 


### PR DESCRIPTION
Currently forwarding errors of forwarded messages doesn't work well

fixing that by changing the order or registration of callbacks and handling errors 