### PR TITLE
feat(test-kit): supported performance.memory in headless withFeature

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -175,7 +175,10 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
     before('launch browser', async function () {
         if (!browser) {
             this.timeout(60_000); // 1 minute
-            browser = await playwright.chromium.launch(withFeatureOptions);
+            browser = await playwright.chromium.launch({
+                ...withFeatureOptions,
+                args: ['--enable-precise-memory-info', ...(withFeatureOptions.args ?? [])],
+            });
         }
     });
 


### PR DESCRIPTION
To access window.performance.memory in headless mode, you must add the `--enable-precise-memory-info` flag when launching chromium.

See StackOverflow: https://stackoverflow.com/a/57829821/13994821