### PR TITLE
fix(electron-scripts): don't copy .bin folder of electron host

### DIFF
--- a/packages/electron-scripts/src/commands/build.ts
+++ b/packages/electron-scripts/src/commands/build.ts
@@ -121,10 +121,10 @@ export async function build(options: IBuildCommandOptions): Promise<void> {
 
     const extraFiles: (string | FileSet)[] = [
         {
-            // Avoid copying binary links of a package;
-            // They contain relative links that will not work in built app, and also break Mac signing
             from: dirname(require.resolve('@wixc3/engine-electron-host/package.json')),
             to: 'node_modules/@wixc3/engine-electron-host',
+            // Avoid copying binary links of a package;
+            // They contain relative links that will not work in built app, and also break Mac signing
             filter: ['!**/node_modules/.bin/**'],
         },
     ];

--- a/packages/electron-scripts/src/commands/build.ts
+++ b/packages/electron-scripts/src/commands/build.ts
@@ -121,8 +121,11 @@ export async function build(options: IBuildCommandOptions): Promise<void> {
 
     const extraFiles: (string | FileSet)[] = [
         {
+            // Avoid copying binary links of a package;
+            // They contain relative links that will not work in built app, and also break Mac signing
             from: dirname(require.resolve('@wixc3/engine-electron-host/package.json')),
             to: 'node_modules/@wixc3/engine-electron-host',
+            filter: ['!**/node_modules/.bin/**'],
         },
     ];
 


### PR DESCRIPTION
* These copied symlinks are broken, and  causes failure of signing process in Mac