### PR TITLE
fix(test-kit)!: don't default to waitUntil: 'networkidle'

### DIFF
--- a/examples/file-server/src/test/file-server.ix.ts
+++ b/examples/file-server/src/test/file-server.ix.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { withFeature } from '@wixc3/engine-test-kit';
+import { waitFor } from 'promise-assist';
 import { expect } from 'chai';
 import { FileServerDriver } from './file-server-driver';
 import fileServerFeature, { SERVER_MARK, MAIN_MARK } from '../feature/file-server.feature';
@@ -41,11 +42,14 @@ describe('File Server Feature', function () {
 
     it('validating metrics are being cleared between runs', async () => {
         const { getMetrics } = await getLoadedFeature();
-        const metrics = await getMetrics();
-        expect(metrics.marks.length).to.eq(2);
-        const browserMark = metrics.marks.find((m) => m.name === MAIN_MARK);
-        const serverMark = metrics.marks.find((m) => m.name === SERVER_MARK);
-        expect(browserMark, 'should receive browser marks').not.be.undefined;
-        expect(serverMark, 'should receive server marks').not.be.undefined;
+
+        await waitFor(async () => {
+            const metrics = await getMetrics();
+            expect(metrics.marks.length).to.eq(2);
+            const browserMark = metrics.marks.find((m) => m.name === MAIN_MARK);
+            const serverMark = metrics.marks.find((m) => m.name === SERVER_MARK);
+            expect(browserMark, 'should receive browser marks').not.be.undefined;
+            expect(serverMark, 'should receive server marks').not.be.undefined;
+        });
     });
 });

--- a/examples/react/src/test/react.ix.ts
+++ b/examples/react/src/test/react.ix.ts
@@ -1,5 +1,4 @@
 import { withFeature } from '@wixc3/engine-test-kit';
-import { expect } from 'chai';
 import { join } from 'path';
 
 describe('React Feature', function () {
@@ -14,7 +13,7 @@ describe('React Feature', function () {
 
     it('Can render react applications', async () => {
         const { page } = await getLoadedFeature();
-        const content = await page.$eval('#loadable', (e) => e.textContent!);
-        expect(content).to.eql('This is from a file');
+
+        await page.locator('#loadable', { hasText: 'This is from a file' }).waitFor({ state: 'visible' });
     });
 });

--- a/packages/engineer/test/gui.unit.ts
+++ b/packages/engineer/test/gui.unit.ts
@@ -71,9 +71,7 @@ describe('engineer:gui', function () {
 
         const page = await loadPage(`http://localhost:${port}/main-dashboard.html?feature=engineer/gui`);
 
-        const text = await page.evaluate(() => document.body.textContent!.trim());
-
-        expect(text).to.include('Feature');
-        expect(text).to.include('Config');
+        await page.locator('body', { hasText: 'Feature' }).waitFor({ state: 'visible' });
+        await page.locator('body', { hasText: 'Config' }).waitFor({ state: 'visible' });
     });
 });

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -69,6 +69,11 @@ export interface IFeatureExecutionOptions {
     tracing?: boolean | Tracing;
 
     /**
+     * Creates a playwright trace file for the test
+     */
+    navigationOptions?: Parameters<playwright.Page['goto']>[1];
+
+    /**
      * Error messages that are allowed to stay unhandled without failing the tests.
      * strings are tested for exact match.
      */
@@ -151,6 +156,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
         featureDiscoveryRoot,
         tracing: suiteTracing = process.env.TRACING ? true : undefined,
         allowedErrors: suiteAllowedErrors = [],
+        navigationOptions: suiteNavigationOptions,
     } = withFeatureOptions;
 
     if (
@@ -210,19 +216,17 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
     });
 
     return {
-        async getLoadedFeature(
-            {
-                featureName = suiteFeatureName,
-                configName = suiteConfigName,
-                runOptions = suiteOptions,
-                queryParams = suiteQueryParams,
-                config = suiteConfig,
-                browserContextOptions = suiteBrowserContextOptions,
-                tracing = suiteTracing,
-                allowedErrors = suiteAllowedErrors,
-            }: IFeatureExecutionOptions = {},
-            navigationOptions?: Parameters<playwright.Page['goto']>[1]
-        ) {
+        async getLoadedFeature({
+            featureName = suiteFeatureName,
+            configName = suiteConfigName,
+            runOptions = suiteOptions,
+            queryParams = suiteQueryParams,
+            config = suiteConfig,
+            browserContextOptions = suiteBrowserContextOptions,
+            tracing = suiteTracing,
+            allowedErrors = suiteAllowedErrors,
+            navigationOptions = suiteNavigationOptions,
+        }: IFeatureExecutionOptions = {}) {
             if (!browser) {
                 throw new Error('Browser is not open!');
             }
@@ -303,10 +307,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
 
             const featurePage = await browserContext.newPage();
 
-            const response = await featurePage.goto(featureUrl + search, {
-                waitUntil: 'networkidle',
-                ...navigationOptions,
-            });
+            const response = await featurePage.goto(featureUrl + search, navigationOptions);
 
             async function getMetrics(): Promise<PerformanceMetrics> {
                 const measures = await executableApp.getMetrics();


### PR DESCRIPTION
users of `withFeature -> getLoadedFeature` can specify whatever `navigationOptions` they want for either per-suite or per-test level