### PR TITLE
fix(test-kit): fallback to non-formatted msg text

### DIFF
--- a/packages/test-kit/src/hook-page-console.ts
+++ b/packages/test-kit/src/hook-page-console.ts
@@ -24,14 +24,15 @@ export function hookPageConsole(
         const { promise, resolve } = deferred();
         const previousMessage = currentMessage;
         currentMessage = promise;
+        const rawMessageText = msg.text(); // contains non-processed formatting
         try {
-            const msgArgs = await Promise.all(msg.args().map((arg) => arg.jsonValue()));
+            const msgArgs: unknown[] = await Promise.all(msg.args().map((arg) => arg.jsonValue()));
             await previousMessage;
             if (filterMessage(messageType, msgArgs)) {
                 consoleFn.apply(console, msgArgs);
             }
         } catch (e) {
-            console.error(e);
+            console.log(rawMessageText);
         } finally {
             resolve();
         }


### PR DESCRIPTION
when serialization fails due to data not being serializable, or target already close, hookPageConsole now prints original non-formatted text instead of the unrelated error