### PR TITLE
fix(test-kit): back to waitUntil: 'networkidle'

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -156,7 +156,9 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
         featureDiscoveryRoot,
         tracing: suiteTracing = process.env.TRACING ? true : undefined,
         allowedErrors: suiteAllowedErrors = [],
-        navigationOptions: suiteNavigationOptions,
+        navigationOptions: suiteNavigationOptions = process.env.SKIP_NETWORK_WAIT
+            ? undefined
+            : { waitUntil: 'networkidle' },
     } = withFeatureOptions;
 
     if (


### PR DESCRIPTION
put the breaking change behind an env flag (SKIP_NETWORK_WAIT) to allow downstream to adapt first.