### PR TITLE
chore: engine communication cleanups

### DIFF
--- a/packages/core/src/communication.feature.ts
+++ b/packages/core/src/communication.feature.ts
@@ -6,9 +6,9 @@ import type { Target } from './com/types';
 import { Config } from './entities/config';
 import { AllEnvironments, Universal } from './entities/env';
 import { Feature } from './entities/feature';
-import { Service } from './entities/service';
+import { Value } from './entities/value';
 import { Slot } from './entities/slot';
-import { RUN_OPTIONS } from './symbols';
+import { RUN_OPTIONS, ENGINE } from './symbols';
 import { LoggerTransport, LogLevel } from './types';
 
 export interface IComConfig {
@@ -52,8 +52,8 @@ export default new Feature({
             })
         ),
         loggerTransports: Slot.withType<LoggerTransport>().defineEntity(Universal),
-        loggerService: Service.withType<LoggerService>().defineEntity(Universal),
-        communication: Service.withType<Communication>().defineEntity(AllEnvironments),
+        loggerService: Value.withType<LoggerService>().defineEntity(Universal),
+        communication: Value.withType<Communication>().defineEntity(AllEnvironments),
     },
 }).setup(
     Universal,
@@ -71,7 +71,7 @@ export default new Feature({
         },
         loggerTransports,
         [RUN_OPTIONS]: runOptions,
-        runningEnvironmentName,
+        [ENGINE]: engine,
         onDispose,
     }) => {
         const isNode = !!process.versions?.node && process.title !== 'browser' && process.type !== 'renderer';
@@ -79,7 +79,8 @@ export default new Feature({
         // worker and iframe always get `name` when initialized as Environment.
         // it can be overridden using top level config.
         // main frame might not have that configured, so we use 'main' fallback for it.
-        const comId = id || (host && host.name) || (typeof self !== 'undefined' && self.name) || runningEnvironmentName;
+        const comId =
+            id || (host && host.name) || (typeof self !== 'undefined' && self.name) || engine.entryEnvironment.env;
 
         const comOptions: ICommunicationOptions = {
             warnOnSlow: runOptions.has('warnOnSlow'),

--- a/packages/core/src/entities/feature.ts
+++ b/packages/core/src/entities/feature.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { RuntimeEngine } from '../runtime-engine';
-import { CREATE_RUNTIME, DISPOSE, IDENTIFY_API, REGISTER_VALUE, RUN, RUN_OPTIONS } from '../symbols';
+import { CREATE_RUNTIME, DISPOSE, ENGINE, IDENTIFY_API, REGISTER_VALUE, RUN, RUN_OPTIONS } from '../symbols';
 import type {
     ContextHandler,
     DisposableContext,
@@ -163,6 +163,7 @@ export class Feature<
                 feature.addOnDisposeHandler(fn, envName);
             },
             [RUN_OPTIONS]: runOptions,
+            [ENGINE]: runningEngine,
             runningEnvironmentName: envName,
         };
 

--- a/packages/core/src/entities/service.ts
+++ b/packages/core/src/entities/service.ts
@@ -1,3 +1,4 @@
+import COM from '../communication.feature';
 import type { AsyncApi, EnvironmentInstanceToken, EnvironmentTypes, ServiceComConfig } from '../com/types';
 import type { RuntimeEngine } from '../runtime-engine';
 import { CREATE_RUNTIME, REGISTER_VALUE } from '../symbols';
@@ -52,7 +53,7 @@ export class Service<
         entityKey: string
     ) {
         if (this.remoteAccess) {
-            const { communication } = runtimeEngine.getCOM().api;
+            const { communication } = runtimeEngine.get(COM).api;
             const serviceKey = runtimeEngine.entityID(featureID, entityKey);
             const providedFrom = normEnvVisibility(this.providedFrom);
             const localEnv = communication.getEnvironmentName();
@@ -78,7 +79,7 @@ export class Service<
     }
 
     public getApiProxy(context: RuntimeEngine, serviceKey: string): any {
-        const { communication } = context.getCOM().api;
+        const { communication } = context.get(COM).api;
         const instanceId = getSingleInstanceId(this.providedFrom);
         if (instanceId) {
             return communication.apiProxy<T>({ id: instanceId }, { id: serviceKey }, this.options);

--- a/packages/core/src/entities/value.ts
+++ b/packages/core/src/entities/value.ts
@@ -1,0 +1,31 @@
+import type { RuntimeEngine } from '../runtime-engine';
+import { CREATE_RUNTIME, REGISTER_VALUE } from '../symbols';
+import type { EnvVisibility } from '../types';
+import { FeatureOutput } from './output';
+
+export class Value<T, ProvidedFrom extends EnvVisibility> extends FeatureOutput<
+    T,
+    T,
+    ProvidedFrom,
+    ProvidedFrom,
+    false
+> {
+    public static withType<T>() {
+        return {
+            defineEntity<E_ENV extends EnvVisibility>(providedFrom: E_ENV) {
+                return new Value<T, E_ENV>(providedFrom);
+            },
+        };
+    }
+    private constructor(public providedFrom: ProvidedFrom) {
+        super(providedFrom, providedFrom, false);
+    }
+
+    public [REGISTER_VALUE](_: RuntimeEngine, providedValue: T) {
+        return providedValue;
+    }
+
+    public [CREATE_RUNTIME]() {
+        return;
+    }
+}

--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -1,4 +1,3 @@
-import COM from './communication.feature';
 import {
     RuntimeFeature,
     Feature,
@@ -81,10 +80,6 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
 
     public entityID(featureId: string, entityKey: string) {
         return `${featureId}.${entityKey}`;
-    }
-
-    public getCOM() {
-        return this.get(COM);
     }
 
     private createConfigMap(topLevelConfig: TopLevelConfig) {

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -5,4 +5,5 @@ export const CREATE_RUNTIME = Symbol.for('__ENGINE__CREATE');
 export const REGISTER_VALUE = Symbol.for('__ENGINE__REGISTER_VALUE');
 export const SERVICE_CONFIG = Symbol.for('__ENGINE__SERVICE_CONFIG');
 export const RUN_OPTIONS = Symbol.for('__ENGINE__RUN_OPTIONS');
+export const ENGINE = Symbol.for('__RUNTIME_ENGINE__');
 export const CONFIGURABLE = Symbol.for('__ENGINE__CONFIGURABLE');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,7 +3,7 @@ import type { LogMessage } from './common-types';
 import type { AnyEnvironment, Environment, GloballyProvidingEnvironments, Universal } from './entities/env';
 import type { Feature } from './entities/feature';
 import type { RuntimeEngine } from './runtime-engine';
-import { CONFIGURABLE, CREATE_RUNTIME, IDENTIFY_API, REGISTER_VALUE, RUN_OPTIONS } from './symbols';
+import { CONFIGURABLE, CREATE_RUNTIME, ENGINE, IDENTIFY_API, REGISTER_VALUE, RUN_OPTIONS } from './symbols';
 
 /*************** HELPER TYPES  ***************/
 
@@ -191,25 +191,15 @@ export interface IRunOptions {
     get(key: string): string | boolean | null | undefined;
 }
 
-type RunningEnvironmentNameForUniversal<ENV> = ENV extends typeof Universal
-    ? {
-          /**
-           * The name of the current running environment while setting up a universal feature.
-           * This is NOT the environment instance id
-           */
-          runningEnvironmentName: string;
-      }
-    : {};
-
 export type SettingUpFeature<ID extends string, API extends EntityRecord, ENV extends AnyEnvironment> = {
     id: ID;
     run: (fn: () => unknown) => void;
     onDispose: (fn: DisposeFunction) => void;
     [RUN_OPTIONS]: IRunOptions;
+    [ENGINE]: RuntimeEngine<ENV>;
 } & MapVisibleInputs<API, GloballyProvidingEnvironments> &
     MapVisibleInputs<API, ENV> &
     MapToProxyType<GetOnlyLocalUniversalOutputs<API>> &
-    RunningEnvironmentNameForUniversal<ENV> &
     MapType<GetDependenciesOutput<API, DeepEnvironmentDeps<ENV>>> &
     MapToProxyType<FilterNotEnv<GetRemoteOutputs<API>, DeepEnvironmentDeps<ENV>, 'providedFrom'>>;
 

--- a/packages/core/test/node/api-type-check.spec.ts
+++ b/packages/core/test/node/api-type-check.spec.ts
@@ -14,6 +14,7 @@ import {
     RuntimeEngine,
     Service,
     Slot,
+    ENGINE,
 } from '@wixc3/engine-core';
 import { typeCheck } from '../type-check';
 
@@ -140,15 +141,15 @@ const env = new Environment('main', 'window', 'single');
 
 /*************** EXAMPLE SETUP FILES ***************/
 export async function dontRun() {
-    addPanel.setup(MAIN, (feature, engine) => {
+    addPanel.setup(MAIN, (feature, features) => {
         feature.componentDescription.register({ component: '', description: '' });
         feature.componentDescription.register({ component: '', description: '' });
-        engine.logger.transport.register({ transportName: `test${engine.logger.config.time}` });
+        features.logger.transport.register({ transportName: `test${features.logger.config.time}` });
 
-        engine.gui.panelSlot.register({ panelID: 'panel1' });
-        engine.gui.panelSlot.register({ panelID: 'panel2' });
+        features.gui.panelSlot.register({ panelID: 'panel1' });
+        features.gui.panelSlot.register({ panelID: 'panel2' });
 
-        engine.gui.guiService.someMethod();
+        features.gui.guiService.someMethod();
 
         const dataPromise = fetch('./some-data');
 
@@ -160,6 +161,8 @@ export async function dontRun() {
             service1.setData(await dataPromise);
         });
 
+        const engine = feature[ENGINE];
+
         typeCheck(
             (
                 _featureTest: ExpectTrue<
@@ -170,6 +173,7 @@ export async function dontRun() {
                             run: (fn: () => unknown) => void;
                             onDispose: (fn: DisposeFunction) => void;
                             [RUN_OPTIONS]: IRunOptions;
+                            [ENGINE]: typeof engine;
                             componentDescription: Registry<ComponentDescription>;
                             service3: DataService;
                         }
@@ -181,7 +185,7 @@ export async function dontRun() {
         typeCheck(
             (
                 _engineTest: EQUAL<
-                    typeof engine,
+                    typeof features,
                     {
                         gui: Running<typeof gui, typeof MAIN>;
                         logger: Running<typeof logger, typeof MAIN>;

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -481,7 +481,7 @@ describe('environment-dependencies communication', () => {
         await env1Engine.run([f]);
         const {
             api: { communication: env1Communication },
-        } = env1Engine.getCOM();
+        } = env1Engine.get(COM);
 
         const env1Target = (
             env1Communication.getEnvironmentHost(env1Communication.getEnvironmentId()) as BaseHost

--- a/packages/core/test/node/runtime.spec.ts
+++ b/packages/core/test/node/runtime.spec.ts
@@ -23,6 +23,7 @@ import {
     SingleEndpointContextualEnvironment,
     Slot,
     Universal,
+    ENGINE,
 } from '@wixc3/engine-core';
 import { typeCheck } from '../type-check';
 
@@ -735,14 +736,17 @@ describe.skip('Environments And Entity Visibility (ONLY TEST TYPES)', () => {
             .setup(main, ({ slot }) => {
                 slot.register({ name: 'test' });
             })
-            .setup(processing, (x) => {
+            .setup(processing, (feature) => {
+                const engine = feature[ENGINE];
+
                 typeCheck(
                     (
                         _noSlot: EQUAL<
-                            typeof x,
+                            typeof feature,
                             {
                                 id: 'echoFeature';
                                 [RUN_OPTIONS]: IRunOptions;
+                                [ENGINE]: typeof engine;
                                 run(fn: () => unknown): unknown;
                                 onDispose(fn: DisposeFunction): unknown;
                             }


### PR DESCRIPTION
This is the start of the effort to move the communication to a separated package also this PR will enable features to access the engine in the setup function

* Pass the `RuntimeEngine` to the `SettingUpFeature`
* Removed `getCOM` from engine runtime (remove coupling prepare for communication split)
* Removed `runningEnvironmentName` (can be accessed via runtime engine)
* Introduce `Value` entity for local provided values

This is a major version