### PR TITLE
fix: return measured result

### DIFF
--- a/packages/performance/index.d.ts
+++ b/packages/performance/index.d.ts
@@ -1,6 +1,18 @@
+type measurement = {
+    duration: number;
+    entryType: string;
+    name: string;
+    startTime: number;
+    toJSON: () => {
+        name: string;
+        startTime: number;
+        duration: number;
+        entryType: string;
+    };
+};
 declare const crossPerformance: {
     mark(markName: string): void;
-    measure(measureName: string, startMark?: string, endMark?: string): void;
+    measure(measureName: string, startMark?: string, endMark?: string): measurement;
     getEntriesByType(type: string): PerformanceMeasure[];
     clearMarks(name?: string): void;
     clearMeasures(name?: string): void;

--- a/packages/performance/index.js
+++ b/packages/performance/index.js
@@ -72,6 +72,7 @@ module.exports = {
         } else {
             measure.push(measurement);
         }
+        return measurement;
     },
     getEntriesByType: (type) => {
         switch (type) {


### PR DESCRIPTION
A minor change to cross-performance.

returns the result a measurement.
updated the d.ts file accordingly


this is a none breaking change since the original return type was void.



_would be useful in the following situation_

```
import performance from '@wixc3/cross-performance';

export const measure = async <T extends (...args: any[]) => any>(label: string, method: T) => {
    const startLabel = `startMeasure: ${label}`;
    const endLabel = `endMeasure: ${label}`;
    performance.mark(startLabel);
    const result = await method();
    performance.mark(endLabel);
    return {
        result,
        measurement: performance.measure(label, startLabel, endLabel),
    };
};

```

```
        const {
            result,
            measurement: { name, duration },
        } = await measure(label, method);
```