### PR TITLE
feat: Add ability to get readonly buckets from slots

### DIFF
--- a/packages/core/src/entities/map-slot.ts
+++ b/packages/core/src/entities/map-slot.ts
@@ -29,11 +29,12 @@ export class MapRegistry<K, T> {
         this.subscribe(cb);
         return () => this.unSubscribe(cb);
     }
-
+    public asMap(): ReadonlyMap<K, T> {
+        return this.items;
+    }
     public get(key: K) {
         return this.items.get(key);
     }
-
     public values() {
         return this.items.values();
     }

--- a/packages/core/src/entities/slot.ts
+++ b/packages/core/src/entities/slot.ts
@@ -20,6 +20,9 @@ export class Registry<T> {
     public unSubscribe(cb: (item: T) => void) {
         this.callbacks.delete(cb);
     }
+    public asArray(): ReadonlyArray<T> {
+        return this.items;
+    }
     public stream(cb: (item: T) => void) {
         for (const item of this) {
             cb(item);


### PR DESCRIPTION
after looking at usages I found many `[...slot].(map|find|reverse)` usages that are redundant loops. 
this PR adds the ability to get the underling registry bucket as readonly  