### PR TITLE
Make Socket.IO transport overridable

### DIFF
--- a/packages/core/src/com/hosts/ws-client-host.ts
+++ b/packages/core/src/com/hosts/ws-client-host.ts
@@ -14,7 +14,7 @@ export class WsClientHost extends BaseHost {
         const { promise, resolve } = deferred();
         this.connected = promise;
 
-        this.socketClient = io(url, { ...options, transports: ['websocket'], forceNew: true });
+        this.socketClient = io(url, { transports: ['websocket'], forceNew: true, ...options });
 
         this.socketClient.on('connect', () => {
             this.socketClient.on('message', (data: unknown) => {

--- a/packages/runtime-node/src/launch-http-server.ts
+++ b/packages/runtime-node/src/launch-http-server.ts
@@ -47,7 +47,7 @@ export async function launchEngineHttpServer({
         openSockets.add(socket);
         socket.once('close', () => openSockets.delete(socket));
     });
-    const socketServer = new io.Server(httpServer, { cors: {}, ...socketServerOptions, transports: ['websocket'] });
+    const socketServer = new io.Server(httpServer, { cors: {}, transports: ['websocket'], ...socketServerOptions });
 
     return {
         close: async () => {


### PR DESCRIPTION
This way we will have socket.io transport defaulted to websockets only with ability to override during application start up like following:
```js
app.run({
    ...options,
    runtimeOptions,
    socketServerOptions: {
        pingTimeout: 60000 * 10,
        transports: ['websocket', 'polling']
    }
})
```

