### PR TITLE
feat(extend-envs-api): Added new methods to work with registered environments

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -74,7 +74,6 @@ export class Communication {
     private messageHandlers = new WeakMap<Target, (options: { data: null | Message }) => void>();
     private disposListeners = new Set<(envId: string) => void>();
     private callbackToEnvMapping = new Map<string, string>();
-    private disposedEnvironments = new Set<string>();
 
     constructor(
         host: Target,
@@ -189,10 +188,10 @@ export class Communication {
         const envTarget = (target as BaseHost).parent ?? target;
         const onTargetMessage = ({ data }: { data: null | Message }) => {
             if (isMessage(data)) {
-                if (!this.disposedEnvironments.has(data.from) && !this.environments[data.from]) {
+                if (!this.environments[data.from]) {
                     this.registerEnv(data.from, envTarget);
                 }
-                if (!this.disposedEnvironments.has(data.origin) && !this.environments[data.origin]) {
+                if (!this.environments[data.origin]) {
                     this.registerEnv(data.origin, envTarget);
                 }
                 this.handleEvent({ data });
@@ -343,10 +342,6 @@ export class Communication {
         return Object.keys(this.environments).filter((id) => id !== '*');
     }
 
-    public resetDisposedEnvironments(): void {
-        this.disposedEnvironments.clear();
-    }
-
     private parseHandlerId(handlerId: string, prelude: string) {
         const [api, method] = handlerId.slice(prelude.length).split('@') as [string, string];
         return {
@@ -431,7 +426,6 @@ export class Communication {
     }
 
     private localyClear(instanceId: string) {
-        this.disposedEnvironments.add(instanceId);
         this.readyEnvs.delete(instanceId);
         this.pendingMessages.deleteKey(instanceId);
         this.pendingEnvs.deleteKey(instanceId);

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -338,6 +338,10 @@ export class Communication {
         return this.environments[envName]?.host;
     }
 
+    /**
+     * Gets a list of all registered environment instance ids.
+     * @returns the list of instance ids.
+     */
     public getRegisteredEnvironmentInstances(): string[] {
         return Object.keys(this.environments).filter((id) => id !== '*');
     }

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -339,6 +339,14 @@ export class Communication {
         return this.environments[envName]?.host;
     }
 
+    public getRegisteredEnvironments(): string[] {
+        return Object.keys(this.environments).filter((id) => id !== '*');
+    }
+
+    public resetDisposedEnvironments(): void {
+        this.disposedEnvironments.clear();
+    }
+
     private parseHandlerId(handlerId: string, prelude: string) {
         const [api, method] = handlerId.slice(prelude.length).split('@') as [string, string];
         return {

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -339,7 +339,7 @@ export class Communication {
         return this.environments[envName]?.host;
     }
 
-    public getRegisteredEnvironmentNames(): string[] {
+    public getRegisteredEnvironmentInstances(): string[] {
         return Object.keys(this.environments).filter((id) => id !== '*');
     }
 

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -339,7 +339,7 @@ export class Communication {
         return this.environments[envName]?.host;
     }
 
-    public getRegisteredEnvironments(): string[] {
+    public getRegisteredEnvironmentNames(): string[] {
         return Object.keys(this.environments).filter((id) => id !== '*');
     }
 


### PR DESCRIPTION
- Added ability to get registered environments using communication API
- Removed `disposedEnvironments` property in order to be able to relaunch disposed env