### PR TITLE
fix(dashboard): dependency graph plus refactor

### DIFF
--- a/packages/dashboard/src/components/dashboard.st.css
+++ b/packages/dashboard/src/components/dashboard.st.css
@@ -13,7 +13,7 @@
     height: 100%;
     display: flex;
     align-items: center;
-    justify-content: center;
+    margin-top: 25px;
     flex-direction: column;
     flex:1;
 }

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -29,7 +29,7 @@ export interface SelectedFeature {
     runtimeArguments?: string;
 }
 
-interface IParams {
+interface IDashboardParams {
     user_feature: string | undefined;
     user_config: string | undefined;
 }
@@ -38,7 +38,7 @@ export interface IDashboardContext {
     serverState: {
         featuresWithRunningNodeEnvs: RunningEngineFeature[];
     };
-    params: IParams;
+    params: IDashboardParams;
     setParams: (t: URLParamsValue<'user_feature' | 'user_config'>) => void;
 }
 

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -131,9 +131,13 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
             ((!params.user_feature && !configName) || (configName && params.user_config === configName))
     );
 
-    const handleSelectedFeature = useCallback((featureName?: string) => {
-        setSelectedFeature(featureName ? featureName : '');
-    }, []);
+    const handleSelectedFeature = useCallback(
+        (featureName = '') => {
+            setSelectedFeature(featureName);
+            setParams({ user_feature: featureName, user_config: params.user_config });
+        },
+        [params.user_config, setParams]
+    );
     serverState.featuresWithRunningNodeEnvs;
 
     return (

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -125,7 +125,7 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
     );
 
     useEffect(() => {
-        if (params.user_feature) selectedFeatureConfig(params.user_feature).catch(console.log);
+        if (params.user_feature) selectedFeatureConfig(params.user_feature).catch(console.warn);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -138,8 +138,6 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
         possibleFeaturesRequest().catch((error) => {
             console.error(error);
         });
-
-        if (params.user_feature) selectedFeatureConfig(params.user_feature);
     }, [fetchServerState]);
 
     const hasNodeEnvironments =

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -40,7 +40,6 @@ export interface IDashboardContext {
     };
     params: IParams;
     setParams: (t: URLParamsValue<'user_feature' | 'user_config'>) => void;
-    selectedFeature: string;
 }
 
 export const DashboardContext = createContext<IDashboardContext>({
@@ -50,7 +49,6 @@ export const DashboardContext = createContext<IDashboardContext>({
         user_feature: undefined,
     },
     setParams: () => console.warn('setParams was not provided to context'),
-    selectedFeature: '',
 });
 
 export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
@@ -67,7 +65,6 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
         user_feature: firstFeatureName,
         user_config: undefined,
     });
-    const [selectedFeature, setSelectedFeature] = useState(params.user_feature || '');
 
     const configNames = useMemo(
         () => serverState.features[params.user_feature || '']?.configurations ?? [],
@@ -133,7 +130,6 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
 
     const handleSelectedFeature = useCallback(
         (featureName = '') => {
-            setSelectedFeature(featureName);
             setParams({ user_feature: featureName, user_config: params.user_config });
         },
         [params.user_config, setParams]
@@ -146,7 +142,6 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
                 serverState: { featuresWithRunningNodeEnvs: serverState.featuresWithRunningNodeEnvs },
                 params,
                 setParams,
-                selectedFeature,
             }}
         >
             <div className={classes.root}>

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -74,9 +74,6 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
         [params.user_feature, serverState.features]
     );
     const [firstConfigName] = configNames;
-
-    // const [selectedFeatureGraph, setSelectedFeatureGraph] = useState<GraphData | null>(null);
-
     const [runtimeArguments, setRuntimeArguments] = useState<Array<IRuntimeOption>>([
         {
             key: '',

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -4,10 +4,10 @@ import { isServerResponseMessage, RunningEngineFeature, ServerState } from '../s
 import { ActionsContainer } from './actions-container';
 import { URLParamsValue, useUrlParams } from './dashboard-hooks';
 import { classes } from './dashboard.st.css';
-import DependencyGraph from './dependency-graph/dependency-graph';
+import { DependencyGraph } from './dependency-graph/dependency-graph';
 import { FeaturesSelection } from './feature-selection';
 import { IRuntimeOption, RuntimeOptionsContainer } from './runtime-options-container';
-import Sidebar from './sidebar/sidebar';
+import { Sidebar } from './sidebar/sidebar';
 
 export interface IDashboardProps {
     fetchServerState: () => Promise<{

--- a/packages/dashboard/src/components/dashboard.tsx
+++ b/packages/dashboard/src/components/dashboard.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState, useCallback, useMemo, createContext } from 'react';
-import { FeaturesSelection } from './feature-selection';
-import { ServerState, isServerResponseMessage, RunningEngineFeature } from '../server-types';
+import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 import type { GraphData } from '../graph-types';
-import { style, classes } from './dashboard.st.css';
-import { RuntimeOptionsContainer, IRuntimeOption } from './runtime-options-container';
+import { isServerResponseMessage, RunningEngineFeature, ServerState } from '../server-types';
 import { ActionsContainer } from './actions-container';
-import { FeatureGraph } from './feature-graph';
 import { URLParamsValue, useUrlParams } from './dashboard-hooks';
+import { classes } from './dashboard.st.css';
+import { FeatureGraph } from './feature-graph';
+import { FeaturesSelection } from './feature-selection';
+import { IRuntimeOption, RuntimeOptionsContainer } from './runtime-options-container';
 import Sidebar from './sidebar/sidebar';
 
 export interface IDashboardProps {
@@ -106,18 +106,6 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
             fetchServerState,
         ]
     );
-
-    useEffect(() => {
-        const possibleFeaturesRequest = async () => {
-            const serverResponse = await fetchServerState();
-            setServerState(serverResponse.data);
-        };
-
-        possibleFeaturesRequest().catch((error) => {
-            console.error(error);
-        });
-    }, [fetchServerState]);
-
     const selectedFeatureConfig = useCallback(
         async (featureName?: string, configName?: string) => {
             setSelectedFeatureGraph(null);
@@ -135,6 +123,24 @@ export const Dashboard = React.memo<IDashboardProps>(function Dashboard({
         },
         [setParams, fetchGraphData]
     );
+
+    useEffect(() => {
+        if (params.user_feature) selectedFeatureConfig(params.user_feature).catch(console.log);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        const possibleFeaturesRequest = async () => {
+            const serverResponse = await fetchServerState();
+            setServerState(serverResponse.data);
+        };
+
+        possibleFeaturesRequest().catch((error) => {
+            console.error(error);
+        });
+
+        if (params.user_feature) selectedFeatureConfig(params.user_feature);
+    }, [fetchServerState]);
 
     const hasNodeEnvironments =
         !!params.user_feature && !!serverState.features[params.user_feature]?.hasServerEnvironments;

--- a/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
+++ b/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
@@ -13,17 +13,14 @@ export const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) =
 
     const { params } = useContext(DashboardContext);
 
-    const applyFeatureGraphData = useCallback(
-        async (featureName = '') => {
+    useEffect(() => {
+        const applyFeatureGraphData = async (featureName = '') => {
             const graphData = await fetchGraphData(featureName);
             setSelectedFeatureGraph(graphData);
-        },
-        [fetchGraphData]
-    );
+        };
 
-    useEffect(() => {
         if (params.user_feature) applyFeatureGraphData(params.user_feature).catch(console.warn);
-    }, [applyFeatureGraphData, params.user_feature]);
+    }, [fetchGraphData, params.user_feature]);
 
     return (
         <>

--- a/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
+++ b/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useEffect, useState } from 'react';
+import React, { FC, useContext, useEffect, useState } from 'react';
 import type { GraphData } from '../../graph-types';
 import { DashboardContext } from '../dashboard';
 import { FeatureGraph } from '../feature-graph';

--- a/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
+++ b/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
@@ -11,10 +11,10 @@ const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
     const [showGraph, setShowGraph] = useState(false);
     const [selectedFeatureGraph, setSelectedFeatureGraph] = useState<GraphData | null>(null);
 
-    const { selectedFeature, params } = useContext(DashboardContext);
+    const { params } = useContext(DashboardContext);
 
-    const selectedFeatureConfig = useCallback(
-        async (featureName: string) => {
+    const applyFeatureGraphData = useCallback(
+        async (featureName = '') => {
             const graphData = await fetchGraphData(featureName);
             setSelectedFeatureGraph(graphData);
         },
@@ -22,8 +22,8 @@ const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
     );
 
     useEffect(() => {
-        if (selectedFeature) selectedFeatureConfig(selectedFeature).catch(console.warn);
-    }, [selectedFeature, selectedFeatureConfig]);
+        if (params.user_feature) applyFeatureGraphData(params.user_feature).catch(console.warn);
+    }, [applyFeatureGraphData, params.user_feature]);
 
     return (
         <>

--- a/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
+++ b/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
@@ -1,0 +1,55 @@
+import React, { FC, useCallback, useContext, useEffect, useState } from 'react';
+import type { GraphData } from '../../graph-types';
+import { DashboardContext } from '../dashboard';
+import { FeatureGraph } from '../feature-graph';
+
+interface IDependencyGraphProps {
+    fetchGraphData: (featureName: string) => Promise<GraphData>;
+}
+
+const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
+    const [showGraph, setShowGraph] = useState(false);
+    const [selectedFeatureGraph, setSelectedFeatureGraph] = useState<GraphData | null>(null);
+
+    const dashboardContext = useContext(DashboardContext);
+
+    const selectedFeatureConfig = useCallback(
+        async (featureName: string) => {
+            const graphData = await fetchGraphData(featureName);
+            setSelectedFeatureGraph(graphData);
+        },
+        [fetchGraphData]
+    );
+
+    useEffect(() => {
+        if (dashboardContext.selectedFeature)
+            selectedFeatureConfig(dashboardContext.selectedFeature).catch(console.warn);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dashboardContext.selectedFeature]);
+
+    return (
+        <>
+            <div>
+                <input
+                    id="feature-graph"
+                    type="checkbox"
+                    checked={showGraph}
+                    onChange={(e) => setShowGraph(e.currentTarget.checked)}
+                />
+                <label htmlFor="feature-graph">Feature Dependency Graph</label>
+            </div>
+            {showGraph &&
+                (dashboardContext.params.user_feature ? (
+                    selectedFeatureGraph ? (
+                        <FeatureGraph selectedFeatureGraph={selectedFeatureGraph} />
+                    ) : (
+                        <div>Loading graph data...</div>
+                    )
+                ) : (
+                    <div>Select a feature to view its dependency graph</div>
+                ))}
+        </>
+    );
+};
+
+export default DependencyGraph;

--- a/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
+++ b/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
@@ -24,8 +24,7 @@ const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
     useEffect(() => {
         if (dashboardContext.selectedFeature)
             selectedFeatureConfig(dashboardContext.selectedFeature).catch(console.warn);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [dashboardContext.selectedFeature]);
+    }, [dashboardContext.selectedFeature, selectedFeatureConfig]);
 
     return (
         <>

--- a/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
+++ b/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
@@ -11,7 +11,7 @@ const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
     const [showGraph, setShowGraph] = useState(false);
     const [selectedFeatureGraph, setSelectedFeatureGraph] = useState<GraphData | null>(null);
 
-    const dashboardContext = useContext(DashboardContext);
+    const { selectedFeature, params } = useContext(DashboardContext);
 
     const selectedFeatureConfig = useCallback(
         async (featureName: string) => {
@@ -22,9 +22,8 @@ const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
     );
 
     useEffect(() => {
-        if (dashboardContext.selectedFeature)
-            selectedFeatureConfig(dashboardContext.selectedFeature).catch(console.warn);
-    }, [dashboardContext.selectedFeature, selectedFeatureConfig]);
+        if (selectedFeature) selectedFeatureConfig(selectedFeature).catch(console.warn);
+    }, [selectedFeature, selectedFeatureConfig]);
 
     return (
         <>
@@ -38,7 +37,7 @@ const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
                 <label htmlFor="feature-graph">Feature Dependency Graph</label>
             </div>
             {showGraph &&
-                (dashboardContext.params.user_feature ? (
+                (params.user_feature ? (
                     selectedFeatureGraph ? (
                         <FeatureGraph selectedFeatureGraph={selectedFeatureGraph} />
                     ) : (

--- a/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
+++ b/packages/dashboard/src/components/dependency-graph/dependency-graph.tsx
@@ -7,7 +7,7 @@ interface IDependencyGraphProps {
     fetchGraphData: (featureName: string) => Promise<GraphData>;
 }
 
-const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
+export const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
     const [showGraph, setShowGraph] = useState(false);
     const [selectedFeatureGraph, setSelectedFeatureGraph] = useState<GraphData | null>(null);
 
@@ -49,5 +49,3 @@ const DependencyGraph: FC<IDependencyGraphProps> = ({ fetchGraphData }) => {
         </>
     );
 };
-
-export default DependencyGraph;

--- a/packages/dashboard/src/components/feature-graph.tsx
+++ b/packages/dashboard/src/components/feature-graph.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect } from 'react';
+import React, { memo, useEffect } from 'react';
 import { hierarchy, cluster, HierarchyPointNode } from 'd3-hierarchy';
 import { line, curveBundle } from 'd3-shape';
-import { select } from 'd3-selection';
+import { select, selectAll } from 'd3-selection';
 import { classes } from './feature-graph.st.css';
 import { translateNodeToHierarchy, xAccessor, yAccessor } from '../graph-utils';
 import type { GraphNode, Node, IFeatureGraphProps } from '../graph-types';
 
-export const FeatureGraph = ({ selectedFeatureGraph }: IFeatureGraphProps) => {
+export const FeatureGraph = memo(({ selectedFeatureGraph }: IFeatureGraphProps) => {
     useEffect(() => {
         // Canvas constants
         const diameter = 600;
@@ -18,6 +18,9 @@ export const FeatureGraph = ({ selectedFeatureGraph }: IFeatureGraphProps) => {
 
         // Line rendering function
         const graphLine = line<HierarchyPointNode<Node>>().x(xAccessor).y(yAccessor).curve(curveBundle.beta(0.7));
+
+        // Clear Graph content
+        selectAll('#graph_root > *').remove();
 
         // Svg canvas init
         const svg = select('#graph_root')
@@ -126,6 +129,6 @@ export const FeatureGraph = ({ selectedFeatureGraph }: IFeatureGraphProps) => {
             });
     });
     return <svg id="graph_root" />;
-};
+});
 
 FeatureGraph.displayName = 'FeatureGraph';

--- a/packages/dashboard/src/components/sidebar/sidebar.tsx
+++ b/packages/dashboard/src/components/sidebar/sidebar.tsx
@@ -1,0 +1,38 @@
+import React, { FC, useContext } from 'react';
+import { DashboardContext } from '../dashboard';
+import { style, classes } from '../dashboard.st.css';
+
+const Sidebar: FC = () => {
+    const dashboardContext = useContext(DashboardContext);
+
+    return (
+        <section className={classes.leftBar}>
+            {dashboardContext.serverState.featuresWithRunningNodeEnvs.length && (
+                <div>
+                    <div className={classes.title}>Running Features:</div>
+                    {dashboardContext.serverState.featuresWithRunningNodeEnvs.map(([f, c]) => (
+                        <button
+                            className={style(classes.runningFeature, {
+                                selected:
+                                    f === dashboardContext.params.user_feature &&
+                                    c === dashboardContext.params.user_config,
+                            })}
+                            key={f + '_' + c}
+                            onClick={() => {
+                                dashboardContext.setParams({
+                                    user_config: c,
+                                    user_feature: f,
+                                });
+                            }}
+                        >
+                            <div>Feature: {f}</div>
+                            <div> config: {c}</div>
+                        </button>
+                    ))}
+                </div>
+            )}
+        </section>
+    );
+};
+
+export default Sidebar;

--- a/packages/dashboard/src/components/sidebar/sidebar.tsx
+++ b/packages/dashboard/src/components/sidebar/sidebar.tsx
@@ -2,7 +2,7 @@ import React, { FC, useContext } from 'react';
 import { DashboardContext } from '../dashboard';
 import { style, classes } from '../dashboard.st.css';
 
-const Sidebar: FC = () => {
+export const Sidebar: FC = () => {
     const { serverState, params, setParams } = useContext(DashboardContext);
 
     return (
@@ -32,5 +32,3 @@ const Sidebar: FC = () => {
         </section>
     );
 };
-
-export default Sidebar;

--- a/packages/dashboard/src/components/sidebar/sidebar.tsx
+++ b/packages/dashboard/src/components/sidebar/sidebar.tsx
@@ -3,23 +3,21 @@ import { DashboardContext } from '../dashboard';
 import { style, classes } from '../dashboard.st.css';
 
 const Sidebar: FC = () => {
-    const dashboardContext = useContext(DashboardContext);
+    const { serverState, params, setParams } = useContext(DashboardContext);
 
     return (
         <section className={classes.leftBar}>
-            {dashboardContext.serverState.featuresWithRunningNodeEnvs.length && (
+            {serverState.featuresWithRunningNodeEnvs.length && (
                 <div>
                     <div className={classes.title}>Running Features:</div>
-                    {dashboardContext.serverState.featuresWithRunningNodeEnvs.map(([f, c]) => (
+                    {serverState.featuresWithRunningNodeEnvs.map(([f, c]) => (
                         <button
                             className={style(classes.runningFeature, {
-                                selected:
-                                    f === dashboardContext.params.user_feature &&
-                                    c === dashboardContext.params.user_config,
+                                selected: f === params.user_feature && c === params.user_config,
                             })}
                             key={f + '_' + c}
                             onClick={() => {
-                                dashboardContext.setParams({
+                                setParams({
                                     user_config: c,
                                     user_feature: f,
                                 });


### PR DESCRIPTION
Bugfixes: 
* Dependency graph not shown on first load
* Dependency graph is now being evaluating based on URL params
* Dependency graph is stacking graphs if the dependency input not cleared entirely (empty string)

Refactor:
* Decoupled `Dashboard` components a bit, introducing two new ones:
    - `dependency-graph`
    - `sidebar`

The refactor purpose is in favor of improving the UX of the dashboard, having it easier to read