### PR TITLE
Handle url with pathname creating WsClientHost

### DIFF
--- a/packages/core/src/com/hosts/ws-client-host.ts
+++ b/packages/core/src/com/hosts/ws-client-host.ts
@@ -11,10 +11,13 @@ export class WsClientHost extends BaseHost {
     constructor(url: string, options?: Partial<SocketOptions>) {
         super();
 
+        const { protocol, host, pathname: path, searchParams } = new URL(url);
+        const query = Object.fromEntries(searchParams as unknown as Iterable<any>);
+
         const { promise, resolve } = deferred();
         this.connected = promise;
 
-        this.socketClient = io(url, { ...options, transports: ['websocket'], forceNew: true });
+        this.socketClient = io(`${protocol}://${host}`, { transports: ['websocket'], forceNew: true, path, query, ...options });
 
         this.socketClient.on('connect', () => {
             this.socketClient.on('message', (data: unknown) => {


### PR DESCRIPTION
Make WsClientHost be able to collect to websocket server hosted at some pathname for example:  wss://manage.wix.com/_api/wcs-gateway