### PR TITLE
chore!: renamed Feature.asEntity to asDependency

### DIFF
--- a/examples/dashboard-extention/src/feature/hello-dash.feature.ts
+++ b/examples/dashboard-extention/src/feature/hello-dash.feature.ts
@@ -3,6 +3,6 @@ import Gui from '@wixc3/engineer/dist/feature/gui.feature';
 
 export default new Feature({
     id: 'dashboardExt',
-    dependencies: [Gui.asEntity],
+    dependencies: [Gui.asDependency],
     api: {},
 });

--- a/examples/electron-app/src/feature/electron-app.feature.ts
+++ b/examples/electron-app/src/feature/electron-app.feature.ts
@@ -14,7 +14,7 @@ export interface IServerApi {
 
 export default new Feature({
     id: 'electronExample',
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     api: {
         echoService: Service.withType<IServerApi>()
             .defineEntity(server)

--- a/examples/electron-app/src/fixtures/example.feature.ts
+++ b/examples/electron-app/src/fixtures/example.feature.ts
@@ -4,5 +4,5 @@ import ElectronApp from '../feature/electron-app.feature';
 export default new Feature({
     id: 'electronAppFixture',
     api: {},
-    dependencies: [ElectronApp.asEntity],
+    dependencies: [ElectronApp.asDependency],
 });

--- a/examples/file-server/src/feature/file-server.feature.ts
+++ b/examples/file-server/src/feature/file-server.feature.ts
@@ -24,7 +24,7 @@ export const SERVER_MARK = 'server';
  */
 export default new Feature({
     id: 'fileServerExample',
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     api: {
         remoteFiles: Service.withType<FileSystemAPI>().defineEntity(server).allowRemoteAccess(),
         config: new Config<{ title?: string }>({}),

--- a/examples/file-server/src/fixtures/example.feature.ts
+++ b/examples/file-server/src/fixtures/example.feature.ts
@@ -9,5 +9,5 @@ export const EXAMPLE_FEATURE_NAME = 'file-server-sample-feature';
 export default new Feature({
     id: EXAMPLE_FEATURE_NAME,
     api: {},
-    dependencies: [FileServer.asEntity],
+    dependencies: [FileServer.asDependency],
 });

--- a/examples/multi-env/src/feature/multi-env.feature.ts
+++ b/examples/multi-env/src/feature/multi-env.feature.ts
@@ -15,7 +15,7 @@ export interface INameProvider {
 
 export default new Feature({
     id: 'contextual-environment-test',
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     api: {
         config: new Config<{ name: string }>({
             name: 'test',

--- a/examples/multi-env/src/fixtures/test-node.feature.ts
+++ b/examples/multi-env/src/fixtures/test-node.feature.ts
@@ -3,7 +3,7 @@ import MultiEnvFeature, { processingEnv } from '../feature/multi-env.feature';
 
 export default new Feature({
     id: 'use-local-server-example',
-    dependencies: [MultiEnvFeature.asEntity],
+    dependencies: [MultiEnvFeature.asDependency],
     api: {},
 });
 

--- a/examples/multi-env/src/fixtures/test-worker.feature.ts
+++ b/examples/multi-env/src/fixtures/test-worker.feature.ts
@@ -3,7 +3,7 @@ import MultiEnvFeature, { processingEnv } from '../feature/multi-env.feature';
 
 export default new Feature({
     id: 'use-worker-example',
-    dependencies: [MultiEnvFeature.asEntity],
+    dependencies: [MultiEnvFeature.asDependency],
     api: {},
 });
 

--- a/examples/playground/src/code-editor/code-editor.feature.ts
+++ b/examples/playground/src/code-editor/code-editor.feature.ts
@@ -16,7 +16,7 @@ export interface SidebarItem {
 
 export default new Feature({
     id: 'playgroundCodeEditor',
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     api: {
         sidebarSlot: Slot.withType<SidebarItem>().defineEntity(MAIN),
         codeService: Service.withType<CodeService>().defineEntity([MAIN, PROCESSING]),

--- a/examples/playground/src/end-with/end-with.feature.ts
+++ b/examples/playground/src/end-with/end-with.feature.ts
@@ -3,6 +3,6 @@ import Preview from '../preview/compiler.feature';
 
 export default new Feature({
     id: 'endWith',
-    dependencies: [Preview.asEntity],
+    dependencies: [Preview.asDependency],
     api: {},
 });

--- a/examples/playground/src/playground.feature.ts
+++ b/examples/playground/src/playground.feature.ts
@@ -5,6 +5,6 @@ import Preview from './preview/compiler.feature';
 
 export default new Feature({
     id: 'enginePlayGroundExample',
-    dependencies: [Code.asEntity, Preview.asEntity, EndWithCompiler.asEntity],
+    dependencies: [Code.asDependency, Preview.asDependency, EndWithCompiler.asDependency],
     api: {},
 });

--- a/examples/playground/src/preview/compiler.feature.ts
+++ b/examples/playground/src/preview/compiler.feature.ts
@@ -6,7 +6,7 @@ export const PREVIEW = new Environment('preview', 'iframe', 'single');
 
 export default new Feature({
     id: 'preview',
-    dependencies: [COM.asEntity, CodeEditor.asEntity],
+    dependencies: [COM.asDependency, CodeEditor.asDependency],
     api: {
         complierExtension: Slot.withType<CompilerExtension>().defineEntity(PROCESSING),
         compileService: Service.withType<BaseCompiler>().defineEntity(PROCESSING).allowRemoteAccess(),

--- a/examples/preload/src/feature/all.feature.ts
+++ b/examples/preload/src/feature/all.feature.ts
@@ -8,7 +8,7 @@ export const workerEnv = new Environment('worker1', 'worker', 'single');
 
 export default new Feature({
     id: 'allfeature',
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     api: {
         nodeEnvMessages: Service.withType<{
             getNodeEnvMessages: () => Array<string>;

--- a/examples/preload/src/feature/preload-context.feature.ts
+++ b/examples/preload/src/feature/preload-context.feature.ts
@@ -13,7 +13,7 @@ export default new Feature({
             .defineEntity(procEnv)
             .allowRemoteAccess(),
     },
-    dependencies: [COM.asEntity, nonContextualFeature.asEntity],
+    dependencies: [COM.asDependency, nonContextualFeature.asDependency],
     context: {
         someCtx: procEnv.withContext<{}>(),
     },

--- a/examples/preload/src/fixtures/parent.feature.ts
+++ b/examples/preload/src/fixtures/parent.feature.ts
@@ -3,6 +3,6 @@ import allFeature from '../feature/all.feature';
 
 export default new Feature({
     id: 'parent',
-    dependencies: [allFeature.asEntity],
+    dependencies: [allFeature.asDependency],
     api: {},
 });

--- a/examples/preload/src/fixtures/preload-context-worker.feature.ts
+++ b/examples/preload/src/fixtures/preload-context-worker.feature.ts
@@ -3,7 +3,7 @@ import contextualFeature, { procEnv } from '../feature/preload-context.feature';
 
 export default new Feature({
     id: 'preloadContextWorker',
-    dependencies: [contextualFeature.asEntity],
+    dependencies: [contextualFeature.asDependency],
     api: {},
 });
 

--- a/examples/react/src/feature/gui.feature.ts
+++ b/examples/react/src/feature/gui.feature.ts
@@ -4,7 +4,7 @@ import reactRendererFeature, { MainEnv } from './react-renderer.feature';
 
 export default new Feature({
     id: 'guiFeature',
-    dependencies: [reactRendererFeature.asEntity],
+    dependencies: [reactRendererFeature.asDependency],
     api: {
         extentionSlot: Slot.withType<React.ReactElement>().defineEntity(MainEnv),
     },

--- a/examples/react/src/feature/someplugin.feature.ts
+++ b/examples/react/src/feature/someplugin.feature.ts
@@ -4,5 +4,5 @@ import guiFeature from './gui.feature';
 export default new Feature({
     id: 'plugin',
     api: {},
-    dependencies: [guiFeature.asEntity],
+    dependencies: [guiFeature.asDependency],
 });

--- a/examples/reloaded-iframe/src/feature/reloaded-iframe.feature.ts
+++ b/examples/reloaded-iframe/src/feature/reloaded-iframe.feature.ts
@@ -9,7 +9,7 @@ export interface IEchoService {
 
 export default new Feature({
     id: 'iframeReload',
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     api: {
         echoService: Service.withType<IEchoService>()
             .defineEntity(iframeEnv)

--- a/packages/core/src/entities/feature.ts
+++ b/packages/core/src/entities/feature.ts
@@ -113,10 +113,6 @@ export class Feature<
      * ```
      */
     public asDependency = this as unknown as Dependency<ID, API, EnvironmentContext>;
-    
-    // TODO: remove after dependent projects are updated
-    // @defecated: use asDependency 
-    public asEntity = this as unknown as Dependency<ID, API, EnvironmentContext>;
 
     /**
      * Unique string that identifies the feature.

--- a/packages/core/test/node/api-type-check.spec.ts
+++ b/packages/core/test/node/api-type-check.spec.ts
@@ -67,7 +67,7 @@ typeCheck(
 
 const gui = new Feature({
     id: 'gui',
-    dependencies: [logger.asEntity],
+    dependencies: [logger.asDependency],
     api: {
         panelSlot: Slot.withType<{ panelID: string }>().defineEntity([MAIN]),
         guiService: Service.withType<{ someMethod(): void }>().defineEntity([MAIN, MAIN_1]),
@@ -108,7 +108,7 @@ interface ComponentDescription {
 
 const addPanel = new Feature({
     id: 'addPanel',
-    dependencies: [gui.asEntity, logger.asEntity],
+    dependencies: [gui.asDependency, logger.asDependency],
     api: {
         componentDescription: Slot.withType<ComponentDescription>().defineEntity(MAIN),
         service1: Service.withType<DataService>().defineEntity(MAIN),

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -481,7 +481,7 @@ describe('environment-dependencies communication', () => {
                 slot1: Slot.withType<string>().defineEntity(base),
                 service2: Service.withType<{ echo: () => string[] }>().defineEntity(env1).allowRemoteAccess(),
             },
-            dependencies: [COM.asEntity],
+            dependencies: [COM.asDependency],
         });
 
         f.setup(base, ({ slot1 }) => {

--- a/packages/core/test/node/env-dependencies.spec.ts
+++ b/packages/core/test/node/env-dependencies.spec.ts
@@ -69,7 +69,7 @@ describe('ENV dependencies', () => {
                     extendingEnv
                 ),
             },
-            dependencies: [entryFeature.asEntity],
+            dependencies: [entryFeature.asDependency],
         });
         entryFeature.setup(baseEnv, ({}) => {
             return {
@@ -152,7 +152,7 @@ describe('ENV dependencies', () => {
 
         new Feature({
             id: 'testFeatureDeps',
-            dependencies: [entryFeature.asEntity],
+            dependencies: [entryFeature.asDependency],
             api: {},
         }).setup(env3, ({}, { entry }) => {
             // We only asset that the types are correct feature runtime does not care.

--- a/packages/core/test/node/runtime.spec.ts
+++ b/packages/core/test/node/runtime.spec.ts
@@ -53,7 +53,7 @@ describe('Feature', () => {
 
         const f2 = new Feature({
             id: 'test2',
-            dependencies: [f1.asEntity],
+            dependencies: [f1.asDependency],
             api: {
                 config: Config.withType<{ name: string }>().defineEntity({ name: 'test2' }),
             },
@@ -69,7 +69,7 @@ describe('Feature', () => {
 
     it('feature run stage', async () => {
         const f0 = new Feature({ id: 'test', api: {} });
-        const entryFeature = new Feature({ id: 'test', api: {}, dependencies: [f0.asEntity] });
+        const entryFeature = new Feature({ id: 'test', api: {}, dependencies: [f0.asDependency] });
         const calls: string[] = [];
 
         f0.setup(AllEnvironments, ({ run }) => {
@@ -91,7 +91,7 @@ describe('Feature', () => {
 
     it('feature setup/run stage should not happen twice', async () => {
         const f0 = new Feature({ id: 'test', api: {} });
-        const f1 = new Feature({ id: 'test', api: {}, dependencies: [f0.asEntity] });
+        const f1 = new Feature({ id: 'test', api: {}, dependencies: [f0.asDependency] });
         const calls: string[] = [];
 
         f0.setup(AllEnvironments, ({ run }) => {
@@ -325,7 +325,7 @@ describe('Feature', () => {
             const entryFeature = new Feature({
                 id: 'testSlotsSecondFeature',
                 api: {},
-                dependencies: [maps.asEntity],
+                dependencies: [maps.asDependency],
             }).setup(mainEnv, ({ }, { testSlotsFeature: { mapSlot } }) => {
                 mapSlot.register('1', 'test');
                 mapSlot.register('2', 'test2');
@@ -359,7 +359,7 @@ describe('Feature', () => {
             const f1 = new Feature({
                 id: 'testSlotsFirstFeature',
                 api: {},
-                dependencies: [maps.asEntity],
+                dependencies: [maps.asDependency],
             }).setup(mainEnv, ({ }, { testSlotsFeature: { mapSlot } }) => {
                 mapSlot.register('1', 'test');
                 mapSlot.register('2', 'test2');
@@ -368,7 +368,7 @@ describe('Feature', () => {
             const f2 = new Feature({
                 id: 'testSlotsSecondFeature',
                 api: {},
-                dependencies: [maps.asEntity],
+                dependencies: [maps.asDependency],
             }).setup(mainEnv, ({ }, { testSlotsFeature: { mapSlot } }) => {
                 mapSlot.register('2', 'test2');
             });
@@ -401,7 +401,7 @@ describe('Feature', () => {
             const entryFeature = new Feature({
                 id: 'testSlotsFirstFeature',
                 api: {},
-                dependencies: [maps.asEntity],
+                dependencies: [maps.asDependency],
             }).setup(mainEnv, () => undefined);
             const engine = await runEngine({ entryFeature, env: mainEnv });
 
@@ -488,7 +488,7 @@ describe('feature interaction', () => {
 
         const entryFeature = new Feature({
             id: 'feature2',
-            dependencies: [echoFeature.asEntity],
+            dependencies: [echoFeature.asDependency],
             api: {
                 config: Config.withType<{ prefix: string; suffix: string }>().defineEntity({ prefix: '', suffix: '' }),
             },
@@ -526,7 +526,7 @@ describe('Contextual environments', () => {
 
         const entryFeature = new Feature({
             id: 'echoFeature',
-            dependencies: [COM.asEntity],
+            dependencies: [COM.asDependency],
             api: {
                 echoService: Service.withType<{ echo(s: string): string }>().defineEntity(processing),
             },
@@ -669,7 +669,7 @@ describe('service with remove access environment visibility', () => {
 
         const echoFeature = new Feature({
             id: 'echoFeature',
-            dependencies: [COM.asEntity],
+            dependencies: [COM.asDependency],
             api: {
                 echoService: Service.withType<{ echo(s: string): string }>()
                     .defineEntity(processing)
@@ -698,7 +698,7 @@ describe('service with remove access environment visibility', () => {
         // const checks = [];
         const testFeature = new Feature({
             id: 'test',
-            dependencies: [echoFeature.asEntity],
+            dependencies: [echoFeature.asDependency],
             api: {},
         });
 
@@ -731,7 +731,7 @@ describe.skip('Environments And Entity Visibility (ONLY TEST TYPES)', () => {
 
         new Feature({
             id: 'echoFeature',
-            dependencies: [COM.asEntity],
+            dependencies: [COM.asDependency],
             api: {
                 slot: Slot.withType<{ name: string }>().defineEntity(main),
             },
@@ -765,7 +765,7 @@ describe.skip('Environments And Entity Visibility (ONLY TEST TYPES)', () => {
 
         const echoFeature = new Feature({
             id: 'echoFeature',
-            dependencies: [COM.asEntity],
+            dependencies: [COM.asDependency],
             api: {
                 echoService: Service.withType<{ echo(s: string): string }>()
                     .defineEntity(processing)
@@ -786,7 +786,7 @@ describe.skip('Environments And Entity Visibility (ONLY TEST TYPES)', () => {
         const checks = [];
         const testFeature = new Feature({
             id: 'test',
-            dependencies: [echoFeature.asEntity],
+            dependencies: [echoFeature.asDependency],
             api: {},
         });
 
@@ -811,7 +811,7 @@ describe.skip('Environments Type tests 1', () => {
 
         const echoFeature = new Feature({
             id: 'echoFeature',
-            dependencies: [COM.asEntity],
+            dependencies: [COM.asDependency],
             api: {
                 // processing,
                 echoService: Service.withType<{ echo(s: string): string }>()

--- a/packages/electron-commons/test/test-project/test-feature.feature.ts
+++ b/packages/electron-commons/test/test-project/test-feature.feature.ts
@@ -10,5 +10,5 @@ export default new Feature({
             handleUncaught: false,
         }),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/packages/engineer/src/feature/dev-server.feature.ts
+++ b/packages/engineer/src/feature/dev-server.feature.ts
@@ -48,7 +48,7 @@ export type ServerListeningHandler = (params: ServerListeningParams) => void | P
 
 export default new Feature({
     id: 'buildFeature',
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     api: {
         /**
          * service providing application level behavior and info, such as node env management, feature detection etc

--- a/packages/engineer/src/feature/gui.feature.ts
+++ b/packages/engineer/src/feature/gui.feature.ts
@@ -12,7 +12,7 @@ export interface EngineerConfig {
 
 export default new Feature({
     id: 'dashboard-gui',
-    dependencies: [buildFeature.asEntity, COM.asEntity],
+    dependencies: [buildFeature.asDependency, COM.asDependency],
     api: {
         /**
          * configuration for building and running the dashboard

--- a/packages/engineer/src/feature/managed.feature.ts
+++ b/packages/engineer/src/feature/managed.feature.ts
@@ -3,6 +3,6 @@ import devServer from './dev-server.feature';
 
 export default new Feature({
     id: 'managedFeature',
-    dependencies: [devServer.asEntity],
+    dependencies: [devServer.asDependency],
     api: {},
 });

--- a/packages/engineer/test/feature-dependency-graph.unit.ts
+++ b/packages/engineer/test/feature-dependency-graph.unit.ts
@@ -9,17 +9,17 @@ const noDepsFeature = new Feature({
 });
 const simpleDepFeature = new Feature({
     id: 'simpleDepFeature',
-    dependencies: [noDepsFeature.asEntity],
+    dependencies: [noDepsFeature.asDependency],
     api: {},
 });
 const shareDepWithDepFeature = new Feature({
     id: 'shareDepWithDepFeature',
-    dependencies: [noDepsFeature.asEntity, simpleDepFeature.asEntity],
+    dependencies: [noDepsFeature.asDependency, simpleDepFeature.asDependency],
     api: {},
 });
 const multiLevelFeature = new Feature({
     id: 'multLevel',
-    dependencies: [simpleDepFeature.asEntity, shareDepWithDepFeature.asEntity],
+    dependencies: [simpleDepFeature.asDependency, shareDepWithDepFeature.asDependency],
     api: {},
 });
 

--- a/packages/runtime-node/test/node-environments-manager.unit.ts
+++ b/packages/runtime-node/test/node-environments-manager.unit.ts
@@ -194,7 +194,7 @@ describe('Node environments manager', function () {
             api: {
                 echoService: Service.withType<{ echo: () => Promise<string> }>().defineEntity(env),
             },
-            dependencies: [SocketServerNodeFeature.asEntity, COM.asEntity],
+            dependencies: [SocketServerNodeFeature.asDependency, COM.asDependency],
         }).setup(env, ({ }, { XTestFeature: { echoService }, COM: { communication } }) => {
             void socketClientInitializer({ communication, env: socketServerEnv });
 
@@ -290,7 +290,7 @@ describe('Node environments manager', function () {
             api: {
                 echoService: Service.withType<{ echo: () => Promise<string> }>().defineEntity(env),
             },
-            dependencies: [ServerNodeFeature.asEntity, COM.asEntity],
+            dependencies: [ServerNodeFeature.asDependency, COM.asDependency],
         }).setup(env, ({ }, { XTestFeature: { echoService }, COM: { communication } }) => {
             void socketClientInitializer({ communication, env: serverEnv });
 

--- a/test-fixtures/application-external/src/application-external.feature.ts
+++ b/test-fixtures/application-external/src/application-external.feature.ts
@@ -6,5 +6,5 @@ export default new Feature({
     api: {
         getValue: Service.withType<{ provider: () => string }>().defineEntity(server).allowRemoteAccess(),
     },
-    dependencies: [BaseApp.asEntity],
+    dependencies: [BaseApp.asDependency],
 });

--- a/test-fixtures/base-web-application/src/base-web-application.feature.ts
+++ b/test-fixtures/base-web-application/src/base-web-application.feature.ts
@@ -12,5 +12,5 @@ export default new Feature({
         iframeSlot: Slot.withType<string>().defineEntity(iframe),
         dataProvider: Service.withType<{ getData(): string[] }>().defineEntity(server).allowRemoteAccess(),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/test-fixtures/contextual/src/feature/some-feature.feature.ts
+++ b/test-fixtures/contextual/src/feature/some-feature.feature.ts
@@ -15,7 +15,7 @@ export default new Feature({
     api: {
         serverService: Service.withType<{ echo: () => string }>().defineEntity(contextualEnv).allowRemoteAccess(),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
     context: {
         echoContext: contextualEnv.withContext<IEchoContext>(),
     },

--- a/test-fixtures/contextual/src/fixtures/server-env.feature.ts
+++ b/test-fixtures/contextual/src/fixtures/server-env.feature.ts
@@ -4,7 +4,7 @@ import MultiEnvFeature, { contextualEnv } from '../feature/some-feature.feature'
 export default new Feature({
     id: 'serverMultiEnvFeature',
     api: {},
-    dependencies: [MultiEnvFeature.asEntity],
+    dependencies: [MultiEnvFeature.asDependency],
 });
 
 export const Context = contextualEnv.useContext('server');

--- a/test-fixtures/engine-config/src/feature/x.feature.ts
+++ b/test-fixtures/engine-config/src/feature/x.feature.ts
@@ -10,5 +10,5 @@ export default new Feature({
         nodeEnv1: Service.withType<{ getPid: () => number }>().defineEntity(NODE_1).allowRemoteAccess(),
         nodeEnv2: Service.withType<{ getPid: () => number }>().defineEntity(NODE_2).allowRemoteAccess(),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/test-fixtures/engine-env-dependency/src/fixtures/variant/variant.feature.ts
+++ b/test-fixtures/engine-env-dependency/src/fixtures/variant/variant.feature.ts
@@ -5,5 +5,5 @@ export const page2 = new Environment('page2', 'window', 'single', [client]);
 export default new Feature({
     id: 'engine-env-dependency-user',
     api: {},
-    dependencies: [App.asEntity],
+    dependencies: [App.asDependency],
 });

--- a/test-fixtures/engine-multi-feature/src/feature/app.feature.ts
+++ b/test-fixtures/engine-multi-feature/src/feature/app.feature.ts
@@ -3,7 +3,7 @@ import { Config, Feature, Slot } from '@wixc3/engine-core';
 
 export default new Feature({
     id: 'MultiFeature',
-    dependencies: [_3rdParty.asEntity],
+    dependencies: [_3rdParty.asDependency],
     api: {
         mySlot: Slot.withType<string>().defineEntity(MAIN),
         myConfig: new Config<{ tags: string[] }>({ tags: [] }),

--- a/test-fixtures/engine-multi-feature/src/fixtures/variant/variant.feature.ts
+++ b/test-fixtures/engine-multi-feature/src/fixtures/variant/variant.feature.ts
@@ -4,5 +4,5 @@ import App from '../../feature/app.feature';
 export default new Feature({
     id: 'Variant',
     api: {},
-    dependencies: [App.asEntity],
+    dependencies: [App.asDependency],
 });

--- a/test-fixtures/engine-run-options/src/feature/x.feature.ts
+++ b/test-fixtures/engine-run-options/src/feature/x.feature.ts
@@ -16,5 +16,5 @@ export default new Feature({
     api: {
         passedOptions: Service.withType<MyInterfaceClass>().defineEntity(PROC).allowRemoteAccess(),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/test-fixtures/engine-runtime-metadata/src/feature/x.feature.ts
+++ b/test-fixtures/engine-runtime-metadata/src/feature/x.feature.ts
@@ -10,5 +10,5 @@ export default new Feature({
             .defineEntity(server)
             .allowRemoteAccess(),
     },
-    dependencies: [COM.asEntity, RuntimeMetadata.asEntity],
+    dependencies: [COM.asDependency, RuntimeMetadata.asDependency],
 });

--- a/test-fixtures/multi-node/src/feature/x.feature.ts
+++ b/test-fixtures/multi-node/src/feature/x.feature.ts
@@ -14,5 +14,5 @@ export default new Feature({
             .allowRemoteAccess(),
         config: Config.withType<{ value: string }>().defineEntity({ value: 'Hello' }, undefined, serverEnv),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/test-fixtures/multi-socket-node/src/feature/x.feature.ts
+++ b/test-fixtures/multi-socket-node/src/feature/x.feature.ts
@@ -14,5 +14,5 @@ export default new Feature({
             .allowRemoteAccess(),
         config: Config.withType<{ value: string }>().defineEntity({ value: 'Hello' }, undefined, serverEnv),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/test-fixtures/node-env/src/feature/x.feature.ts
+++ b/test-fixtures/node-env/src/feature/x.feature.ts
@@ -8,5 +8,5 @@ export default new Feature({
         echoService: Service.withType<{ echo: () => string }>().defineEntity(serverEnv).allowRemoteAccess(),
         config: Config.withType<{ value: string }>().defineEntity({ value: 'Hello' }, undefined, serverEnv),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/test-fixtures/static-application-external/src/application-external.feature.ts
+++ b/test-fixtures/static-application-external/src/application-external.feature.ts
@@ -4,5 +4,5 @@ import BaseApp from '@fixture/static-base-web-application-feature/dist/base-web-
 export default new Feature({
     id: 'extenalFeature',
     api: {},
-    dependencies: [BaseApp.asEntity],
+    dependencies: [BaseApp.asDependency],
 });

--- a/test-fixtures/static-base-web-application/src/base-web-application.feature.ts
+++ b/test-fixtures/static-base-web-application/src/base-web-application.feature.ts
@@ -14,5 +14,5 @@ export default new Feature({
         clientSlot: Slot.withType<string>().defineEntity(client),
         iframeSlot: Slot.withType<string>().defineEntity(iframe),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });

--- a/test-fixtures/using-config/src/fixtures/fixture.feature.ts
+++ b/test-fixtures/using-config/src/fixtures/fixture.feature.ts
@@ -3,6 +3,6 @@ import UseConfigsFeature from '../feature/use-configs.feature';
 
 export default new Feature({
     id: 'alternativeDisplay',
-    dependencies: [UseConfigsFeature.asEntity],
+    dependencies: [UseConfigsFeature.asDependency],
     api: {},
 });

--- a/test-fixtures/with-iframe/src/feature/x.feature.ts
+++ b/test-fixtures/with-iframe/src/feature/x.feature.ts
@@ -9,5 +9,5 @@ export default new Feature({
             .defineEntity(iframeEnv)
             .allowRemoteAccess(),
     },
-    dependencies: [COM.asEntity],
+    dependencies: [COM.asDependency],
 });


### PR DESCRIPTION
Dropped support for Feature.asEntity (rename - breaking change)