### PR TITLE
feat(node-environment-initializer): Updated node environment initializer to be synchronous

### DIFF
--- a/packages/electron-commons/src/initializers/electron-node.ts
+++ b/packages/electron-commons/src/initializers/electron-node.ts
@@ -15,7 +15,7 @@ export interface InitializeNodeEnvironmentOptions extends InitializerOptions {
 /**
  * Spawn a node-based environment from the renderer process.
  * Should be invoked *only* from the renderer process.
- * The caller should await returned `environmentIsReady` to ensure environment initialization is finished.
+ * The caller should await returned `environmentIsReady` promise to ensure environment initialization is finished.
  */
 
 export const initializeNodeEnvironment: EnvironmentInitializer<

--- a/packages/electron-commons/test/initializers/electron-node.spec.ts
+++ b/packages/electron-commons/test/initializers/electron-node.spec.ts
@@ -31,23 +31,23 @@ const setupRunningEnv = async ({
 }: { errorMode?: 'exception' | 'exit' | 'promiseReject'; handleUncaught?: boolean } = {}) => {
     const communication = new Communication(new BaseHost(), 'someId');
     const { features } = findFeatures(testProjectPath, 'dist');
-    const { onDisconnect, dispose } = await initializeNodeEnvironment({
+    const { onDisconnect, dispose, environmentIsReady } = initializeNodeEnvironment({
         communication,
         env: serverEnv,
-        getApplicationMetaData: () =>
-            Promise.resolve({
-                featureName: testFeature.id,
-                basePath: testProjectPath,
-                outputPath: fs.join(testProjectPath, 'dist-app'),
-                nodeEntryPath: fs.join(testProjectPath, 'entry.js'),
-                config: [testFeature.use({ errorType: { type: errorMode, handleUncaught } })],
-                features: Array.from(features.entries()),
-                externalFeatures: [],
-                env: serverEnv,
-            }),
+        runtimeArguments: {
+            featureName: testFeature.id,
+            basePath: testProjectPath,
+            outputPath: fs.join(testProjectPath, 'dist-app'),
+            nodeEntryPath: fs.join(testProjectPath, 'entry.js'),
+            config: [testFeature.use({ errorType: { type: errorMode, handleUncaught } })],
+            features: Array.from(features.entries()),
+            externalFeatures: [],
+        },
         processOptions: { cwd: process.cwd() },
         environmentStartupOptions: {},
     });
+
+    await environmentIsReady;
 
     const disconnectPromise = new Promise<boolean>((res) => {
         onDisconnect(() => {

--- a/packages/electron-node/src/initializers/node-process.ts
+++ b/packages/electron-node/src/initializers/node-process.ts
@@ -14,13 +14,17 @@ import {
 
 export const initializeNodeEnvironmentInNode: EnvironmentInitializer<
     Promise<IActiveEnvironment>,
-    Omit<InitializeNodeEnvironmentOptions, 'getApplicationMetaData'>
+    Omit<InitializeNodeEnvironmentOptions, 'runtimeArguments'>
 > = async (options) => {
-    const { id, dispose, onDisconnect } = await initializeNodeEnvironment({
-        getApplicationMetaData: (com) => getApplicationMetaData(com),
+    const runtimeArguments = await getApplicationMetaData(options.communication);
+    const { id, dispose, onDisconnect, environmentIsReady } = initializeNodeEnvironment({
+        runtimeArguments,
         ...options,
     });
     process.on('exit', dispose);
+
+    await environmentIsReady;
+
     return { id, onDisconnect };
 };
 

--- a/packages/electron/src/initializers/electron-node.ts
+++ b/packages/electron/src/initializers/electron-node.ts
@@ -15,16 +15,20 @@ import type { EnvironmentInitializer, IActiveEnvironment } from '@wixc3/engine-c
 
 export const initializeNodeEnvironmentInBrowser: EnvironmentInitializer<
     Promise<IActiveEnvironment>,
-    Omit<InitializeNodeEnvironmentOptions, 'getApplicationMetaData'>
+    Omit<InitializeNodeEnvironmentOptions, 'runtimeArguments'>
 > = async ({ communication, env, environmentStartupOptions, processOptions }) => {
-    const { id, dispose, onDisconnect } = await initializeNodeEnvironment({
+    const runtimeArguments = await getApplicationMetaData();
+    const { id, dispose, onDisconnect, environmentIsReady } = initializeNodeEnvironment({
         environmentStartupOptions,
         env,
         communication,
-        getApplicationMetaData,
+        runtimeArguments,
         processOptions,
     });
     window.addEventListener('beforeunload', dispose);
+
+    await environmentIsReady;
+
     return { id, onDisconnect };
 };
 


### PR DESCRIPTION
Changed function `initializeNodeEnvironment` to be synchronous instead of async.
The callers might need this to have immediate access to the `dispose` function.
This is needed cause, in some cases, application exit might be requested in between two moments: the environment is already spawned, and the environment did not send a callback via communication yet. Example use case: close electron application in one second after window appear. Because closing the window causes the host for the electron-renderer process to be disposed (at least I think so), the `envReady` event is not triggered via communication for the newly created environment.
In that case, the caller will never be able to dispose such env cause it will not be registered, and dispose function will not be returned. However, the process will be already spawned. In that case, the caller will have running background processes with those environments, which is not good.