### PR TITLE
fix(communication): Fixed circular message forwarding

### DIFF
--- a/packages/core-node/src/ipc-host.ts
+++ b/packages/core-node/src/ipc-host.ts
@@ -20,6 +20,7 @@ export class IPCHost extends BaseHost implements IDisposable {
                     type: 'dispose',
                     to: '*',
                     origin: env,
+                    forwardingChain: [],
                 });
             }
         });
@@ -41,6 +42,7 @@ export class IPCHost extends BaseHost implements IDisposable {
                     type: 'dispose',
                     to: '*',
                     origin: data.to,
+                    forwardingChain: [],
                 });
             }
         };

--- a/packages/core-node/src/ws-node-host.ts
+++ b/packages/core-node/src/ws-node-host.ts
@@ -81,6 +81,7 @@ export class WsServerHost extends BaseHost implements IDisposable {
                     from: env,
                     origin: env,
                     to: '*',
+                    forwardingChain: [],
                 });
             }
         });

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -175,7 +175,8 @@ export class Communication {
                                 method,
                                 args,
                                 this.rootEnvId,
-                                serviceComConfig as Record<string, AnyServiceMethodOptions>
+                                serviceComConfig as Record<string, AnyServiceMethodOptions>,
+                                []
                             );
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
                         obj[method] = runtimeMethod;
@@ -233,7 +234,8 @@ export class Communication {
         method: string,
         args: unknown[],
         origin: string,
-        serviceComConfig: Record<string, AnyServiceMethodOptions>
+        serviceComConfig: Record<string, AnyServiceMethodOptions>,
+        forwardingChain: string[]
     ): Promise<unknown> {
         return new Promise<void>((res, rej) => {
             const callbackId = !serviceComConfig[method]?.emitOnly ? this.idsCounter.next('c') : undefined;
@@ -247,7 +249,7 @@ export class Communication {
                     origin,
                     serviceComConfig,
                     args[0] as UnknownFunction,
-                    [],
+                    forwardingChain,
                     res,
                     rej
                 );
@@ -259,7 +261,7 @@ export class Communication {
                     data: { api, method, args },
                     callbackId,
                     origin,
-                    forwardingChain: [this.rootEnvId],
+                    forwardingChain,
                 };
                 this.callWithCallback(envId, message, callbackId, res, rej);
             }
@@ -488,7 +490,8 @@ export class Communication {
                     message.data.method,
                     message.data.args,
                     message.origin,
-                    {}
+                    {},
+                    message.forwardingChain
                 );
 
                 if (message.callbackId) {

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -247,6 +247,7 @@ export class Communication {
                     origin,
                     serviceComConfig,
                     args[0] as UnknownFunction,
+                    [],
                     res,
                     rej
                 );
@@ -543,6 +544,7 @@ export class Communication {
                 message.origin,
                 { [message.data.method]: { listener: true } },
                 handler,
+                message.forwardingChain,
                 res,
                 rej
             );
@@ -582,6 +584,7 @@ export class Communication {
         origin: string,
         serviceComConfig: Record<string, AnyServiceMethodOptions>,
         fn: UnknownFunction,
+        forwardingChain: string[],
         res: () => void,
         rej: () => void
     ) {
@@ -612,7 +615,7 @@ export class Communication {
                     },
                     handlerId: listenerHandlerId,
                     origin,
-                    forwardingChain: [this.rootEnvId],
+                    forwardingChain,
                 };
                 // sometimes the callback will never happen since target environment is already dead
                 this.sendTo(envId, message);
@@ -644,7 +647,7 @@ export class Communication {
                         handlerId: this.createHandlerRecord(envId, api, method, fn),
                         callbackId,
                         origin,
-                        forwardingChain: [this.rootEnvId],
+                        forwardingChain,
                     };
 
                     this.callWithCallback(envId, message, callbackId, res, rej);
@@ -772,6 +775,7 @@ export class Communication {
                     },
                 },
                 this.eventDispatchers[message.handlerId]!,
+                message.forwardingChain,
                 res,
                 rej
             )

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -612,7 +612,7 @@ export class Communication {
                     },
                     handlerId: listenerHandlerId,
                     origin,
-                    forwardingChain: [],
+                    forwardingChain: [this.rootEnvId],
                 };
                 // sometimes the callback will never happen since target environment is already dead
                 this.sendTo(envId, message);
@@ -644,7 +644,7 @@ export class Communication {
                         handlerId: this.createHandlerRecord(envId, api, method, fn),
                         callbackId,
                         origin,
-                        forwardingChain: [],
+                        forwardingChain: [this.rootEnvId],
                     };
 
                     this.callWithCallback(envId, message, callbackId, res, rej);

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -471,7 +471,7 @@ export class Communication {
             this.sendTo(message.from, {
                 ...responseMessage,
                 error: new Error(
-                    `cannot reach environment '${message.to}' from '${message.from}' as stuck in circular message forwarding`
+                    `cannot reach environment '${message.to}' from '${message.from}' since it's stuck in circular messaging loop`
                 ),
             });
             return;

--- a/packages/core/src/com/message-types.ts
+++ b/packages/core/src/com/message-types.ts
@@ -12,6 +12,7 @@ export interface BaseMessage {
     callbackId?: string;
     error?: Error;
     origin: string;
+    forwardingChain: string[];
 }
 
 export interface CallMessage extends BaseMessage {


### PR DESCRIPTION
Added `forwardingChain` property to the message object so we can detect and fail on circular message forwarding.

When a message is forwarded from one env to another, we add the current instance id to a `forwardingChain` array, so we can detect if the same message comes to our instance circularly and fail this message.