### PR TITLE
feat!: public path default set to empty

### DIFF
--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -17,7 +17,7 @@ import type { ServerListeningHandler } from './feature/dev-server.types';
 
 const parseBoolean = (value: string) => value === 'true';
 const collectMultiple = (val: string, prev: string[]) => [...prev, val];
-const defaultPublicPath = process.env.ENGINE_PUBLIC_PATH || '/';
+const defaultPublicPath = process.env.ENGINE_PUBLIC_PATH || '';
 
 export type CliCommand = (program: Command) => void;
 

--- a/packages/engineer/src/utils.types.ts
+++ b/packages/engineer/src/utils.types.ts
@@ -35,7 +35,7 @@ export interface IStartOptions {
 export const defaultOptions = {
     httpServerPort: 3000,
     pathsToRequire: [],
-    publicPath: '/',
+    publicPath: '',
     mode: 'development',
     publicConfigsRoute: 'configs/',
     autoLaunch: true,


### PR DESCRIPTION
public path is set to '' now by default.

Why?
* in codux I want to use bundled files from root and from path, thus I want relative assets


Why don't codux passes publicPath: '' instead of change in default param?
* there is no reason to have  / by default 