### PR TITLE
fix(naming): changing tracing file default name

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -298,7 +298,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                             name:
                                 process.env.TRACING && process.env.TRACING !== 'true'
                                     ? process.env.TRACING
-                                    : name ?? testName?.replace(/(\W+)/gi, '-').slice(31) + 'trace',
+                                    : name ?? `${testName?.replace(/(\W+)/gi, '-').slice(31)}trace`,
                         }),
                     });
                 });

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -298,7 +298,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                             name:
                                 process.env.TRACING && process.env.TRACING !== 'true'
                                     ? process.env.TRACING
-                                    : name ?? testName?.replace(/(\W+)/gi, '-').slice(1),
+                                    : name ?? testName?.replace(/(\W+)/gi, '-').slice(31) + 'trace',
                         }),
                     });
                 });

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -298,7 +298,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                             name:
                                 process.env.TRACING && process.env.TRACING !== 'true'
                                     ? process.env.TRACING
-                                    : name ?? `${testName?.replace(/(\W+)/gi, '-').slice(31)}trace`,
+                                    : name ?? testName?.replace(/(\W+)/gi, ' ').trim().replace(/(\W+)/gi, '-'),
                         }),
                     });
                 });


### PR DESCRIPTION
Currently, the output trace file name might be (as a default name) the test name without the first letter =>
 `flaky-test => laky-test.zip`
 This PR should fix it