### PR TITLE
fix(test-kit): tracing now extracts correct test title

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -278,17 +278,18 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
             browserContext.on('page', onPageCreation);
             disposeAfter(() => browserContext.off('page', onPageCreation), PAGE_DISPOSABLES);
 
-            const sanitizedSuiteTracing = typeof suiteTracing === 'boolean' ? {} : suiteTracing;
-            const sanitizedTracing = typeof tracing === 'boolean' ? {} : tracing;
+            const suiteTracingOptions = typeof suiteTracing === 'boolean' ? {} : suiteTracing;
+            const testTracingOptions = typeof tracing === 'boolean' ? {} : tracing;
 
-            if (sanitizedTracing) {
-                const { screenshots, snapshots, name, outPath } = {
-                    ...sanitizedTracing,
-                    ...sanitizedSuiteTracing,
+            if (testTracingOptions) {
+                const combinedTrancingOptions = {
                     screenshots: true,
                     snapshots: true,
                     outPath: process.cwd(),
+                    ...suiteTracingOptions,
+                    ...testTracingOptions,
                 };
+                const { screenshots, snapshots, name, outPath } = combinedTrancingOptions;
                 await browserContext.tracing.start({ screenshots, snapshots });
                 tracingDisposables.add((testName) => {
                     return browserContext.tracing.stop({
@@ -304,7 +305,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                 });
                 disposeAfter(async () => {
                     for (const tracingDisposable of tracingDisposables) {
-                        await tracingDisposable(mochaCtx()?.test?.title);
+                        await tracingDisposable(mochaCtx()?.currentTest?.title);
                     }
                     tracingDisposables.clear();
                 });


### PR DESCRIPTION
also fixed the ability to override options from the suite or the test itself. renamed a few variables for clarity.