### PR TITLE
infra: reformat all sources using latest prettier

### DIFF
--- a/docs/runtime.entities.environment.md
+++ b/docs/runtime.entities.environment.md
@@ -26,7 +26,7 @@ The possible targets for an environment
 | window            | an environment which will be bundled, and html will be created for it and will append the bundle to the head of the html |
 | iframe            | very similar to the window environment, with the exception that it is ment to be a source of an ifame element            |
 | node              | node environment                                                                                                         |
-| webworker         | environment which will be loaded in a browser webworker                                                                     |
+| webworker         | environment which will be loaded in a browser webworker                                                                  |
 | electron-renderer | an environment which will be executed in an electron browser window                                                      |
 | electron-main     | the root electron process                                                                                                |
 | context           | [[runtime.entities.environment.targets.context]]                                                                         |

--- a/packages/core/src/com/initializers/iframe.ts
+++ b/packages/core/src/com/initializers/iframe.ts
@@ -35,7 +35,7 @@ export async function iframeInitializer({
     const { initialize } = deferredIframeInitializer({ communication, env });
     const id = await initialize(initializerOptions);
     return {
-        id
+        id,
     };
 }
 
@@ -55,10 +55,10 @@ export function deferredIframeInitializer({ communication: com, env: { env, endp
                 envReadyPromise,
                 instanceId,
                 iframe: iframeElement,
-                src: src ?? defaultHtmlSourceFactory(env, publicPath, hashParams, origin)
+                src: src ?? defaultHtmlSourceFactory(env, publicPath, hashParams, origin),
             };
             return startIframe(startIframeParams);
-        }
+        },
     };
 }
 
@@ -106,8 +106,8 @@ async function startIframe({ com, iframe, instanceId, src, envReadyPromise }: St
             { id: WindowInitializerService.apiId },
             {
                 oncePageHide: {
-                    listener: true
-                }
+                    listener: true,
+                },
             }
         );
         const postInitHref = await api.getHref();

--- a/packages/core/src/entities/feature.ts
+++ b/packages/core/src/entities/feature.ts
@@ -13,7 +13,7 @@ import type {
     RunningFeatures,
     SetupHandler,
     IFeature,
-    Dependency
+    Dependency,
 } from '../types';
 import { AnyEnvironment, Environment, testEnvironmentCollision } from './env';
 import { SetMultiMap } from '@wixc3/patterns';
@@ -63,7 +63,7 @@ export class RuntimeFeature<T extends IFeature, ENV extends AnyEnvironment> {
 
     public async [DISPOSE](context: RuntimeEngine) {
         const {
-            entryEnvironment: { env: envName }
+            entryEnvironment: { env: envName },
         } = context;
         if (this.disposing) {
             return this.disposing.promise;
@@ -211,7 +211,7 @@ export class Feature<
             features,
             runOptions,
             referencedEnvs,
-            entryEnvironment: { env: envName }
+            entryEnvironment: { env: envName },
         } = runningEngine;
 
         const deps: any = {};
@@ -248,7 +248,7 @@ export class Feature<
             },
             [RUN_OPTIONS]: runOptions,
             [ENGINE]: runningEngine,
-            runningEnvironmentName: envName
+            runningEnvironmentName: envName,
         };
 
         for (const [key, contextHandler] of this.contextHandlers) {

--- a/packages/core/src/entities/slot.ts
+++ b/packages/core/src/entities/slot.ts
@@ -53,7 +53,7 @@ export class Slot<Type extends Registry<any>, ProvidedFrom extends EnvVisibility
              */
             defineEntity<E_ENV extends EnvVisibility>(env: E_ENV) {
                 return new Slot<Registry<T>, E_ENV>(env, env);
-            }
+            },
         };
     }
     public [CREATE_RUNTIME]() {

--- a/packages/core/test/node/api-type-check.spec.ts
+++ b/packages/core/test/node/api-type-check.spec.ts
@@ -85,7 +85,7 @@ typeCheck((_: EQUAL<SomeApiPromisified, { someMethod(): Promise<boolean> }>) => 
 typeCheck(
     (
         _runningDependencies: EQUAL<
-            RunningFeatures<typeof gui['dependencies'], typeof MAIN>,
+            RunningFeatures<(typeof gui)['dependencies'], typeof MAIN>,
             { logger: Running<typeof logger, typeof MAIN> }
         >,
         _runningFeature: EQUAL<
@@ -127,7 +127,7 @@ typeCheck(
             }
         >,
         _runningDependencies: EQUAL<
-            RunningFeatures<typeof addPanel['dependencies'], typeof MAIN>,
+            RunningFeatures<(typeof addPanel)['dependencies'], typeof MAIN>,
             {
                 logger: Running<typeof logger, typeof MAIN>;
                 gui: Running<typeof gui, typeof MAIN>;

--- a/packages/core/test/node/env-dependencies.spec.ts
+++ b/packages/core/test/node/env-dependencies.spec.ts
@@ -191,7 +191,7 @@ describe('ENV dependencies', () => {
             typeCheck(
                 (
                     _runningFeature: EQUAL<
-                        typeof entry['service'],
+                        (typeof entry)['service'],
                         {
                             get(token: EnvironmentInstanceToken): AsyncApi<{ increment: (n: number) => number }>;
                         }
@@ -201,7 +201,7 @@ describe('ENV dependencies', () => {
             typeCheck(
                 (
                     _runningFeature: EQUAL<
-                        typeof entry['service2'],
+                        (typeof entry)['service2'],
                         {
                             get(
                                 token: EnvironmentInstanceToken

--- a/packages/electron-node/src/initializers/browser-window.ts
+++ b/packages/electron-node/src/initializers/browser-window.ts
@@ -18,7 +18,7 @@ export interface BrowserWindowEnvironmentInitializerOptions extends InitializerO
 export function windowEnvironmentInitializer({
     browserWindow,
     env: { env: envName },
-    communication: com
+    communication: com,
 }: BrowserWindowEnvironmentInitializerOptions): InitializedBrowserEnvironment {
     const host = new ElectronBrowserHost(ipcMain, browserWindow.webContents);
     com.registerEnv(envName, host);
@@ -30,7 +30,7 @@ export function windowEnvironmentInitializer({
             com.clearEnvironment(envName);
             com.removeMessageHandler(host);
         }),
-        browserWindow
+        browserWindow,
     };
 }
 
@@ -51,7 +51,7 @@ export async function initializeWindowEnvironment({
     const query = {
         feature: featureName,
         config: configName ?? '',
-        ...runtimeArguments
+        ...runtimeArguments,
     };
     if (devport) {
         const url = new URL(`http://localhost:${devport}/${env.env}.html`);

--- a/packages/electron-scripts/src/commands/build.ts
+++ b/packages/electron-scripts/src/commands/build.ts
@@ -6,7 +6,7 @@ import {
     Application,
     getExportedEnvironments,
     IApplicationOptions,
-    IBuildCommandOptions as IEngineBuildCommandOptions
+    IBuildCommandOptions as IEngineBuildCommandOptions,
 } from '@wixc3/engine-scripts';
 import { build as electronBuild, Configuration, FileSet, PublishOptions } from 'electron-builder';
 import { dirname, posix, relative } from 'path';
@@ -82,7 +82,7 @@ export async function build(options: IBuildCommandOptions): Promise<void> {
         mac,
         windows,
         featureDiscoveryRoot = configFeatureDiscoveryRoot,
-        publish
+        publish,
     } = options;
     const outputPath = fs.join(basePath, outDir);
     if (!isPublishValid(publish)) {
@@ -113,7 +113,7 @@ export async function build(options: IBuildCommandOptions): Promise<void> {
         configName,
         config,
         features,
-        outDir
+        outDir,
     });
 
     const configFullPath = fs.resolve(fs.join(basePath, electronBuilderConfigFileName));
@@ -125,8 +125,8 @@ export async function build(options: IBuildCommandOptions): Promise<void> {
             to: 'node_modules/@wixc3/engine-electron-host',
             // Avoid copying binary links of a package;
             // They contain relative links that will not work in built app, and also break Mac signing
-            filter: ['!**/node_modules/.bin/**']
-        }
+            filter: ['!**/node_modules/.bin/**'],
+        },
     ];
 
     const configFiles = builderConfig.extraFiles;
@@ -143,14 +143,14 @@ export async function build(options: IBuildCommandOptions): Promise<void> {
             electronVersion,
             extraMetadata: {
                 ...(builderConfig.extraMetadata as Record<string, string>),
-                main: fs.join(outDir, ELECTRON_ENTRY_FILE_NAME)
+                main: fs.join(outDir, ELECTRON_ENTRY_FILE_NAME),
             },
-            extraFiles
+            extraFiles,
         },
         linux: linux ? [] : undefined,
         mac: mac ? [] : undefined,
         win: windows ? [] : undefined,
-        publish
+        publish,
     });
 }
 function isPublishValid(publish?: string | null): publish is PublishOptions['publish'] {
@@ -178,14 +178,14 @@ export function createElectronEntryFile({
     configName,
     config,
     features,
-    outDir
+    outDir,
 }: CreateElectronEntryOptions): Promise<void> {
     const currentFeature = features.get(featureName);
 
     const env = [...getExportedEnvironments(features)].find(({ name }) => name === envName)?.env;
 
     if (!env) {
-        throw new Error(`cannot create electron entry for ${envName}. No feature found exporing this environment`);
+        throw new Error(`cannot create electron entry for ${envName}. No feature found exporting this environment`);
     }
 
     if (!currentFeature) {
@@ -216,23 +216,23 @@ export function createElectronEntryFile({
                     contextFilePaths: Object.fromEntries(
                         Object.entries(contextFilePaths).map(([key, value]) => [
                             key,
-                            mapAbsolutePathsToRequests(value, packageName)
+                            mapAbsolutePathsToRequests(value, packageName),
                         ])
                     ),
                     envFilePaths: Object.fromEntries(
                         Object.entries(envFilePaths).map(([key, value]) => [
                             key,
-                            mapAbsolutePathsToRequests(value, packageName)
+                            mapAbsolutePathsToRequests(value, packageName),
                         ])
                     ),
                     filePath: mapAbsolutePathsToRequests(filePath, packageName),
                     preloadFilePaths: Object.fromEntries(
                         Object.entries(preloadFilePaths).map(([key, value]) => [
                             key,
-                            mapAbsolutePathsToRequests(value, packageName)
+                            mapAbsolutePathsToRequests(value, packageName),
                         ])
-                    )
-                }
+                    ),
+                },
             ];
         }
     );
@@ -292,6 +292,6 @@ export async function bundleEngineApp(options: IBundleEngineArguments): ReturnTy
 
     return app.build({
         ...options,
-        singleFeature: true
+        singleFeature: true,
     });
 }

--- a/packages/engineer/src/utils.ts
+++ b/packages/engineer/src/utils.ts
@@ -19,7 +19,7 @@ export async function startDevServer(options: IStartOptions): Promise<{
 }> {
     const serverOpts = defaults(options, defaultOptions);
     const app = new TargetApplication({
-        basePath: serverOpts.targetApplicationPath
+        basePath: serverOpts.targetApplicationPath,
     });
     const { config } = await app.getEngineConfig();
     const engineCnf = defaults(config || ({} as EngineConfig), defaultsEngineConfig);
@@ -28,7 +28,7 @@ export async function startDevServer(options: IStartOptions): Promise<{
           fs.join(basePath, 'dev-server.feature.ts')
         : // include all features (gui, managed etc)
           fs.findFilesSync(basePath, {
-              filterFile: ({ name }) => isFeatureFile(name)
+              filterFile: ({ name }) => isFeatureFile(name),
           });
     preRequire([...serverOpts.pathsToRequire, ...engineCnf.require], basePath);
 
@@ -43,7 +43,7 @@ export async function startDevServer(options: IStartOptions): Promise<{
         host: new BaseHost(),
         config: [
             devServerFeature.use({
-                devServerConfig: asDevConfig(serverOpts, engineCnf)
+                devServerConfig: asDevConfig(serverOpts, engineCnf),
             }),
             ...(options.devServerOnly
                 ? []
@@ -62,7 +62,7 @@ export async function startDevServer(options: IStartOptions): Promise<{
         engine,
         outputPath: app.outputPath,
         dispose,
-        devServerFeature: engine.get(devServerFeature).api
+        devServerFeature: engine.get(devServerFeature).api,
     };
 }
 
@@ -72,7 +72,7 @@ function asDevConfig(options: DStartOptions, engineConfig: DEngineConfig): Parti
         favicon: options.favicon ?? engineConfig.favicon,
         basePath: options.targetApplicationPath,
         defaultRuntimeOptions: options.runtimeOptions,
-        featureDiscoveryRoot: options.featureDiscoveryRoot ?? engineConfig.featureDiscoveryRoot
+        featureDiscoveryRoot: options.featureDiscoveryRoot ?? engineConfig.featureDiscoveryRoot,
     };
 }
 

--- a/packages/runtime-node/src/process-communication.ts
+++ b/packages/runtime-node/src/process-communication.ts
@@ -40,7 +40,7 @@ export function createIPC(
             //TODO: check
             for (const [envName, config] of message.data.config ?? []) {
                 if (envName === COM.id) {
-                    const typedConfig = (config as PartialFeatureConfig<typeof COM['api']>).config ?? {};
+                    const typedConfig = (config as PartialFeatureConfig<(typeof COM)['api']>).config ?? {};
                     const { connectedEnvironments: definedConnectedEnvironments } = typedConfig;
                     if (definedConnectedEnvironments) {
                         for (const [envToken, envRecord] of Object.entries(definedConnectedEnvironments)) {

--- a/packages/scripts/src/analyze-feature/load-features-from-paths.ts
+++ b/packages/scripts/src/analyze-feature/load-features-from-paths.ts
@@ -7,7 +7,7 @@ import {
     parseConfigFileName,
     parseContextFileName,
     parseEnvFileName,
-    parsePreloadFileName
+    parsePreloadFileName,
 } from '../build-constants';
 import { loadFeatureDirectory } from '../load-feature-directory';
 import { evaluateModule } from '../utils/evaluate-module';
@@ -122,7 +122,7 @@ function analyzeFeature(filePath: string, featurePackage: IPackageDescriptor): A
         scopedName,
         evaluated,
         module,
-        filePath
+        filePath,
     };
 }
 
@@ -153,16 +153,16 @@ function parseFoundFeature(
                 exportedEnvs: this.exportedEnvs,
                 resolvedContexts: this.resolvedContexts,
                 packageName: this.packageName,
-                scopedName
+                scopedName,
             };
-        }
+        },
     };
 }
 
 function getImportedFeatures(roots: DirFeatures, fs: IFileSystemSync): DirFeatures {
     const imported = {
         dirs: new Set<string>(),
-        files: new Set<string>()
+        files: new Set<string>(),
     };
     // find all require()'ed feature files from initial ones
     const featureModules = getFeatureModules(evaluateModule(roots.files));

--- a/packages/scripts/src/application/application.ts
+++ b/packages/scripts/src/application/application.ts
@@ -9,7 +9,7 @@ import {
     launchEngineHttpServer,
     NodeEnvironmentsManager,
     resolveEnvironments,
-    RouteMiddleware
+    RouteMiddleware,
 } from '@wixc3/engine-runtime-node';
 import { SetMultiMap } from '@wixc3/patterns';
 import express from 'express';
@@ -19,7 +19,7 @@ import { ENGINE_CONFIG_FILE_NAME } from '../build-constants';
 import {
     createCommunicationMiddleware,
     createConfigMiddleware,
-    ensureTopLevelConfigMiddleware
+    ensureTopLevelConfigMiddleware,
 } from '../config-middleware';
 import { createExternalNodeEntrypoint } from '../create-entrypoint';
 import { createWebpackConfig, createWebpackConfigs } from '../create-webpack-configs';
@@ -64,12 +64,12 @@ export class Application {
         const buildOptions = defaults(options, buildDefaults);
         const { config: _config } = await this.getEngineConfig();
         const config = defaults(_config || {}, buildDefaults);
-        
+
         if (config.require) await this.importModules(config.require);
 
         const entryPoints: Record<string, Record<string, string>> = {};
         const analyzed = this.analyzeFeatures(buildOptions.featureDiscoveryRoot ?? config.featureDiscoveryRoot);
-        
+
         if (buildOptions.singleFeature && buildOptions.featureName) {
             this.filterByFeatureName(analyzed.features, buildOptions.featureName);
         }
@@ -115,7 +115,7 @@ export class Application {
         const {
             serveStatic = [],
             socketServerOptions: configSocketServerOptions,
-            require: requiredPaths = []
+            require: requiredPaths = [],
         } = engineConfig ?? {};
 
         const routeMiddlewares: RouteMiddleware[] = [];
@@ -131,7 +131,7 @@ export class Application {
             staticDirPath: this.outputPath,
             httpServerPort,
             socketServerOptions,
-            routeMiddlewares
+            routeMiddlewares,
         });
         disposables.add(close);
 
@@ -156,7 +156,7 @@ export class Application {
             app.use(`/${publicConfigsRoute}`, [
                 ensureTopLevelConfigMiddleware,
                 createCommunicationMiddleware(nodeEnvironmentManager, publicPath),
-                createConfigMiddleware(config)
+                createConfigMiddleware(config),
             ]);
         }
 
@@ -164,7 +164,7 @@ export class Application {
             await nodeEnvironmentManager.runServerEnvironments({
                 featureName,
                 configName,
-                mode: nodeEnvironmentsMode ?? engineConfig?.nodeEnvironmentsMode
+                mode: nodeEnvironmentsMode ?? engineConfig?.nodeEnvironmentsMode,
             });
         }
 
@@ -172,7 +172,7 @@ export class Application {
             port,
             router: app,
             nodeEnvironmentManager,
-            close: disposables.dispose
+            close: disposables.dispose,
         };
     }
 
@@ -185,7 +185,7 @@ export class Application {
                 filePath: require.resolve(filePath, { paths: [this.outputPath] }),
                 envFilePaths: this.resolveManifestPaths(envFilePaths),
                 contextFilePaths: this.resolveManifestPaths(contextFilePaths),
-                preloadFilePaths: this.resolveManifestPaths(preloadFilePaths)
+                preloadFilePaths: this.resolveManifestPaths(preloadFilePaths),
             });
         }
         return features;
@@ -195,7 +195,7 @@ export class Application {
         return Object.fromEntries(
             Object.entries(envFilePaths).map<[string, string]>(([envName, filePath]) => [
                 envName,
-                require.resolve(filePath, { paths: [this.outputPath] })
+                require.resolve(filePath, { paths: [this.outputPath] }),
             ])
         );
     }
@@ -211,7 +211,7 @@ export class Application {
         const { socketServer, close, port } = await launchEngineHttpServer({
             staticDirPath: this.outputPath,
             httpServerPort: preferredPort,
-            socketServerOptions
+            socketServerOptions,
         });
 
         const parentProcess = new ForkedProcess(process);
@@ -239,7 +239,7 @@ export class Application {
             featureName,
             targetPath,
             templatesDirPath,
-            featureDirNameTemplate
+            featureDirNameTemplate,
         });
     }
 
@@ -249,7 +249,7 @@ export class Application {
             try {
                 return {
                     config: (await import(engineConfigFilePath)) as EngineConfig,
-                    path: engineConfigFilePath
+                    path: engineConfigFilePath,
                 };
             } catch (ex) {
                 throw new Error(`failed evaluating config file: ${engineConfigFilePath}`);
@@ -282,7 +282,7 @@ export class Application {
                     const featureName = entity.name;
                     const featureConfigsDirectory = join(configsDirectoryPath, featureName);
                     const featureConfigsEntities = await fs.promises.readdir(featureConfigsDirectory, {
-                        withFileTypes: true
+                        withFileTypes: true,
                     });
                     for (const possibleConfigFile of featureConfigsEntities) {
                         const fileExtention = extname(possibleConfigFile.name);
@@ -333,8 +333,8 @@ export class Application {
             featureName,
             {
                 ...{ ...featureDef },
-                ...this.mapFeatureFiles(featureDef, sourcesRoot)
-            } as IFeatureDefinition
+                ...this.mapFeatureFiles(featureDef, sourcesRoot),
+            } as IFeatureDefinition,
         ];
     }
 
@@ -346,7 +346,7 @@ export class Application {
             packageName,
             preloadFilePaths,
             isRoot,
-            directoryPath
+            directoryPath,
         }: IFeatureDefinition,
         sourcesRoot: string
     ) {
@@ -398,7 +398,7 @@ export class Application {
                 context,
                 isRoot && outputDirInBasePath,
                 preloadFilePaths
-            )
+            ),
         };
     }
 
@@ -427,7 +427,7 @@ export class Application {
         webpackConfigPath,
         environments,
         eagerEntrypoint,
-        configLoaderModuleName
+        configLoaderModuleName,
     }: ICompilerOptions) {
         const { basePath, outputPath } = this;
         const baseConfigPath = webpackConfigPath
@@ -455,7 +455,7 @@ export class Application {
             singleFeature,
             createWebpackConfig,
             eagerEntrypoint,
-            configLoaderModuleName
+            configLoaderModuleName,
         });
         const compiler = webpack(webpackConfigs);
         hookCompilerToConsole(compiler);
@@ -483,7 +483,7 @@ export class Application {
             const entryCode = createExternalNodeEntrypoint({
                 ...reMappedFeature,
                 childEnvs,
-                env
+                env,
             });
             fs.writeFileSync(entryPath, entryCode);
         }
@@ -505,7 +505,7 @@ export class Application {
             featureEnvDefinitions[scopedName] = {
                 configurations: configNames.filter((name) => name.includes(rootFeatureName)),
                 hasServerEnvironments: resolveEnvironments(scopedName, features, 'node').size > 0,
-                featureName: scopedName
+                featureName: scopedName,
             };
         }
 
@@ -528,7 +528,7 @@ export class Application {
                     }
                     return feature;
                 })
-            )
+            ),
         ].map(({ scopedName }) => scopedName);
         if (nonFoundDependencies.length) {
             throw new Error(

--- a/packages/scripts/src/feature-generator/feature-generator.ts
+++ b/packages/scripts/src/feature-generator/feature-generator.ts
@@ -11,7 +11,7 @@ export function generateFeature({
     featureName,
     targetPath,
     templatesDirPath,
-    featureDirNameTemplate = DEFAULT_FEATURE_DIR_NAME_TEMPLATE
+    featureDirNameTemplate = DEFAULT_FEATURE_DIR_NAME_TEMPLATE,
 }: IGeneratorOptions) {
     const templatesDir = readDirectoryContentsSync(fs, templatesDirPath);
     const templateContext = enrichContext({ featureName });
@@ -37,7 +37,7 @@ export const templateParser = (
 
     return {
         name: mappedFileName,
-        content: content ? templateCompiler(content) : undefined
+        content: content ? templateCompiler(content) : undefined,
     };
 };
 

--- a/packages/scripts/test/merge.unit.ts
+++ b/packages/scripts/test/merge.unit.ts
@@ -7,15 +7,15 @@ describe('mergeAll', () => {
         const actual: { a: Map<number, number>; b: Set<number> } = mergeAll([
             { a: new Map([[0, 0]]), b: new Set([0]) },
             { a: new Map([[1, 1]]), b: new Set([1]) },
-            { a: new Map([[2, 2]]), b: new Set([2]) }
+            { a: new Map([[2, 2]]), b: new Set([2]) },
         ]);
         expect(actual).to.eql({
             a: new Map([
                 [0, 0],
                 [1, 1],
-                [2, 2]
+                [2, 2],
             ]),
-            b: new Set([0, 1, 2])
+            b: new Set([0, 1, 2]),
         });
     });
 });
@@ -27,7 +27,7 @@ describe('mergeResults', () => {
             expect(actual).to.eql(
                 new Map([
                     [0, 0],
-                    [1, 1]
+                    [1, 1],
                 ])
             );
         });
@@ -45,7 +45,7 @@ describe('mergeResults', () => {
             expect(actual).to.eql(
                 new SetMultiMap([
                     [0, 0],
-                    [1, 1]
+                    [1, 1],
                 ])
             );
         });
@@ -56,7 +56,7 @@ describe('mergeResults', () => {
             expect(actual).to.eql(
                 new SetMultiMap([
                     [0, 0],
-                    [0, 1]
+                    [0, 1],
                 ])
             );
         });
@@ -80,24 +80,24 @@ describe('mergeResults', () => {
                 {
                     a: new SetMultiMap([[0, 0]]),
                     b: new Map([[0, 0]]),
-                    c: new Set([0])
+                    c: new Set([0]),
                 },
                 {
                     a: new SetMultiMap([[0, 1]]),
                     b: new Map([[1, 1]]),
-                    c: new Set([1])
+                    c: new Set([1]),
                 }
             );
             expect(actual).to.eql({
                 a: new SetMultiMap([
                     [0, 0],
-                    [0, 1]
+                    [0, 1],
                 ]),
                 b: new Map([
                     [0, 0],
-                    [1, 1]
+                    [1, 1],
                 ]),
-                c: new Set([0, 1])
+                c: new Set([0, 1]),
             });
         });
 
@@ -109,20 +109,20 @@ describe('mergeResults', () => {
             } = mergeResults(
                 {
                     a: new SetMultiMap([[0, 0]]),
-                    b: new Map([[0, 0]])
+                    b: new Map([[0, 0]]),
                 },
                 {
                     b: new Map([[1, 1]]),
-                    c: new Set([1])
+                    c: new Set([1]),
                 }
             );
             expect(actual).to.eql({
                 a: new SetMultiMap([[0, 0]]),
                 b: new Map([
                     [0, 0],
-                    [1, 1]
+                    [1, 1],
                 ]),
-                c: new Set([1])
+                c: new Set([1]),
             });
         });
     });

--- a/packages/test-kit/src/supported-browsers.ts
+++ b/packages/test-kit/src/supported-browsers.ts
@@ -1,5 +1,5 @@
 const supportedBrowsers = ['chromium', 'firefox', 'webkit'] as const;
-export type SupportedBrowser = typeof supportedBrowsers[number];
+export type SupportedBrowser = (typeof supportedBrowsers)[number];
 
 export function isValidBrowserName(browserName: string): browserName is SupportedBrowser {
     return (supportedBrowsers as ReadonlyArray<string>).includes(browserName);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,8 +7,8 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.json'],
         alias: {
-            sinon: 'sinon/pkg/sinon-esm.js'
-        }
+            sinon: 'sinon/pkg/sinon-esm.js',
+        },
     },
     module: {
         rules: [


### PR DESCRIPTION
* run `npx prettier . --write`
* fix typo in `electron-scripts/src/commands/build` (exporting instead of exporing)