### PR TITLE
feat: expose environment disconnect details

### DIFF
--- a/packages/electron-commons/src/expirable-list.ts
+++ b/packages/electron-commons/src/expirable-list.ts
@@ -1,5 +1,5 @@
 /**
- * The collection of items that expires items on the specified expiration timeout.
+ * A list where items are automatically removed after a certain timeout.
  */
 export class ExpirableList<T> {
     private items: { item: T; timestamp: number }[] = [];

--- a/packages/electron-commons/src/expirable-list.ts
+++ b/packages/electron-commons/src/expirable-list.ts
@@ -1,0 +1,37 @@
+/**
+ * The collection of items that expires items on the specified expiration timeout.
+ */
+export class ExpirableList<T> {
+    private items: { item: T; timestamp: number }[] = [];
+
+    /**
+     * @param expirationTimeMilliseconds the time to live for items in milliseconds
+     */
+    constructor(private expirationTimeMilliseconds: number) {}
+
+    /**
+     * Adds new item to a collection
+     */
+    public push(item: T): void {
+        this.removeExpiredItems();
+        this.items.push({
+            item,
+            timestamp: performance.now(),
+        });
+    }
+
+    /**
+     * @returns the list of non-expired items
+     */
+    public getItems(): T[] {
+        this.removeExpiredItems();
+        return this.items.map(({ item }) => item);
+    }
+
+    private removeExpiredItems() {
+        const currentTimestamp = performance.now();
+        this.items = this.items.filter(
+            ({ timestamp }) => timestamp + this.expirationTimeMilliseconds > currentTimestamp
+        );
+    }
+}

--- a/packages/electron-commons/src/initializers/electron-node.ts
+++ b/packages/electron-commons/src/initializers/electron-node.ts
@@ -84,7 +84,7 @@ export const initializeNodeEnvironment: EnvironmentInitializer<
     child.stderr?.setEncoding('utf8');
     child.stdout?.on('data', console.log); // eslint-disable-line no-console
 
-    const errorChunks = new ExpirableList<string>(5 * 1000);
+    const errorChunks = new ExpirableList<string>(5_000);
 
     child.stderr?.on('data', (chunk) => {
         console.error(chunk); // eslint-disable-line no-console

--- a/packages/electron-commons/src/initializers/electron-node.ts
+++ b/packages/electron-commons/src/initializers/electron-node.ts
@@ -29,7 +29,7 @@ export interface ProcessExitDetails {
     /**
      * The last output process sent to stderr stream
      */
-    lastSeenError: string | undefined;
+    lastSeenError: string | null;
 }
 
 /**
@@ -114,7 +114,7 @@ export const initializeNodeEnvironment: EnvironmentInitializer<
         },
         onDisconnect: (cb: (details: ProcessExitDetails) => void) => {
             child.once('exit', (exitCode, signal) => {
-                cb({ exitCode, signal, lastSeenError: lastErrors.join('') });
+                cb({ exitCode, signal, lastSeenError: lastErrors.length > 0 ? lastErrors.join('') : null });
             });
         },
         environmentIsReady,

--- a/packages/electron-commons/test/initializers/electron-node.spec.ts
+++ b/packages/electron-commons/test/initializers/electron-node.spec.ts
@@ -55,10 +55,10 @@ const setupRunningEnv = async ({
 };
 
 describe('onDisconnectHandler for node environment initializer', () => {
-    const expectedProcessExitDetails = {
+    const expectedProcessExitDetails: ProcessExitDetails = {
         exitCode: 1,
         signal: null,
-        lastSeenError: undefined,
+        lastSeenError: null,
     };
 
     describe('without own uncaughtException handling', () => {

--- a/packages/electron-commons/test/initializers/electron-node.spec.ts
+++ b/packages/electron-commons/test/initializers/electron-node.spec.ts
@@ -1,9 +1,11 @@
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import fs from '@file-services/node';
 import { BaseHost, Communication } from '@wixc3/engine-core';
+import { initializeNodeEnvironment, ProcessExitDetails } from '@wixc3/engine-electron-commons';
 import { findFeatures } from '@wixc3/engine-scripts';
-import { DisconnectDetails, initializeNodeEnvironment } from '@wixc3/engine-electron-commons';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import type { IOType } from 'child_process';
+import { deferred } from 'promise-assist';
 import testFeature, { serverEnv } from '../test-project/test-feature.feature';
 
 const { expect } = chai;
@@ -14,8 +16,12 @@ const testProjectPath = fs.join(__dirname, '../test-project');
 const setupRunningEnv = async ({
     errorMode,
     handleUncaught,
-    pipeOutput,
-}: { errorMode?: 'exception' | 'exit' | 'promiseReject'; handleUncaught?: boolean; pipeOutput?: boolean } = {}) => {
+    stdio = 'ignore',
+}: {
+    errorMode?: 'exception' | 'exit' | 'promiseReject' | 'out-of-memory';
+    handleUncaught?: boolean;
+    stdio?: IOType;
+} = {}) => {
     const communication = new Communication(new BaseHost(), 'someId');
     const { features } = findFeatures(testProjectPath, fs, 'dist');
     const { onDisconnect, dispose, environmentIsReady } = initializeNodeEnvironment({
@@ -31,60 +37,61 @@ const setupRunningEnv = async ({
         },
         processOptions: {
             cwd: process.cwd(),
-            stdio: pipeOutput === true ? ['pipe', 'pipe', 'pipe', 'ipc'] : ['ignore', 'ignore', 'ignore', 'ipc'],
+            stdio: [stdio, stdio, stdio, 'ipc'],
         },
         environmentStartupOptions: {},
     });
 
     await environmentIsReady;
 
-    const disconnectPromise = new Promise<DisconnectDetails>((res) => {
-        onDisconnect(res);
-    });
+    const disconnect = deferred<ProcessExitDetails>();
+    onDisconnect(disconnect.resolve);
 
     return {
         onDisconnect,
         dispose,
-        disconnectPromise,
+        disconnectPromise: disconnect.promise,
     };
 };
 
 describe('onDisconnectHandler for node environment initializer', () => {
+    const expectedProcessExitDetails = {
+        exitCode: 1,
+        signal: null,
+        lastSeenError: undefined,
+    };
+
     describe('without own uncaughtException handling', () => {
         it('should catch on dispose of env', async () => {
             const { dispose, disconnectPromise } = await setupRunningEnv();
 
             dispose();
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should catch on env exit intentionally', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exit' });
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await disconnectPromise;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should catch on env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should expose disconnect reason when env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
-            await expect(disconnectPromise).to.eventually.be.deep.eq({
-                exitCode: 1,
-                signal: null,
-                lastSeenError: undefined,
-            });
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should catch on env unhandled promise rejection', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'promiseReject' });
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should expose error when env throwing uncaught exception', async () => {
-            const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', pipeOutput: true });
+            const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', stdio: 'pipe' });
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
             const disconnectDetails = await disconnectPromise;
             expect(disconnectDetails.lastSeenError).to.not.be.empty;
         });
@@ -96,35 +103,30 @@ describe('onDisconnectHandler for node environment initializer', () => {
 
             dispose();
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should catch on env exit intentionally', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exit', handleUncaught });
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should catch on env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', handleUncaught });
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should expose disconnect reason when env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
-            await expect(disconnectPromise).to.eventually.be.deep.eq({
-                exitCode: 1,
-                signal: null,
-                lastSeenError: undefined,
-            });
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should catch on env unhandled promise rejection', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'promiseReject', handleUncaught });
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
+            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should expose disconnect reason when env throwing uncaught exception', async () => {
-            const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', pipeOutput: true });
+            const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', stdio: 'pipe' });
 
-            await expect(disconnectPromise).to.eventually.be.fulfilled;
             const disconnectDetails = await disconnectPromise;
             expect(disconnectDetails.lastSeenError).to.not.be.empty;
         });

--- a/packages/electron-commons/test/initializers/electron-node.spec.ts
+++ b/packages/electron-commons/test/initializers/electron-node.spec.ts
@@ -79,7 +79,7 @@ describe('onDisconnectHandler for node environment initializer', () => {
 
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
-        it('should expose disconnect reason when env throwing uncaught exception', async () => {
+        it('should expose process exit details when env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
@@ -114,7 +114,7 @@ describe('onDisconnectHandler for node environment initializer', () => {
 
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
-        it('should expose disconnect reason when env throwing uncaught exception', async () => {
+        it('should expose process exit details when env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
@@ -123,12 +123,6 @@ describe('onDisconnectHandler for node environment initializer', () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'promiseReject', handleUncaught });
 
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
-        });
-        it('should expose disconnect reason when env throwing uncaught exception', async () => {
-            const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', stdio: 'pipe' });
-
-            const disconnectDetails = await disconnectPromise;
-            expect(disconnectDetails.lastSeenError).to.not.be.empty;
         });
     });
 });

--- a/packages/electron-commons/test/initializers/electron-node.spec.ts
+++ b/packages/electron-commons/test/initializers/electron-node.spec.ts
@@ -71,15 +71,9 @@ describe('onDisconnectHandler for node environment initializer', () => {
         });
         it('should catch on env exit intentionally', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exit' });
-            await disconnectPromise;
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });
         it('should catch on env throwing uncaught exception', async () => {
-            const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
-
-            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
-        });
-        it('should expose process exit details when env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
@@ -91,7 +85,6 @@ describe('onDisconnectHandler for node environment initializer', () => {
         });
         it('should expose error when env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', stdio: 'pipe' });
-
             const disconnectDetails = await disconnectPromise;
             expect(disconnectDetails.lastSeenError).to.not.be.empty;
         });
@@ -111,11 +104,6 @@ describe('onDisconnectHandler for node environment initializer', () => {
         });
         it('should catch on env throwing uncaught exception', async () => {
             const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception', handleUncaught });
-
-            await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
-        });
-        it('should expose process exit details when env throwing uncaught exception', async () => {
-            const { disconnectPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
             await expect(disconnectPromise).to.eventually.deep.eq(expectedProcessExitDetails);
         });

--- a/packages/electron-node/src/initializers/node-process.ts
+++ b/packages/electron-node/src/initializers/node-process.ts
@@ -17,7 +17,7 @@ export const initializeNodeEnvironmentInNode: EnvironmentInitializer<
     Omit<InitializeNodeEnvironmentOptions, 'runtimeArguments'>
 > = async (options) => {
     const runtimeArguments = await getApplicationMetaData(options.communication);
-    const { id, dispose, onDisconnect, environmentIsReady } = initializeNodeEnvironment({
+    const { id, dispose, onExit, environmentIsReady } = initializeNodeEnvironment({
         runtimeArguments,
         ...options,
     });
@@ -25,7 +25,7 @@ export const initializeNodeEnvironmentInNode: EnvironmentInitializer<
 
     await environmentIsReady;
 
-    return { id, onDisconnect };
+    return { id, onExit };
 };
 
 async function getApplicationMetaData(com: Communication) {

--- a/packages/electron/src/initializers/electron-node.ts
+++ b/packages/electron/src/initializers/electron-node.ts
@@ -18,7 +18,7 @@ export const initializeNodeEnvironmentInBrowser: EnvironmentInitializer<
     Omit<InitializeNodeEnvironmentOptions, 'runtimeArguments'>
 > = async ({ communication, env, environmentStartupOptions, processOptions }) => {
     const runtimeArguments = await getApplicationMetaData();
-    const { id, dispose, onDisconnect, environmentIsReady } = initializeNodeEnvironment({
+    const { id, dispose, onExit, environmentIsReady } = initializeNodeEnvironment({
         environmentStartupOptions,
         env,
         communication,
@@ -29,7 +29,7 @@ export const initializeNodeEnvironmentInBrowser: EnvironmentInitializer<
 
     await environmentIsReady;
 
-    return { id, onDisconnect };
+    return { id, onExit };
 };
 
 async function getApplicationMetaData() {


### PR DESCRIPTION
Expose environment disconnect details such as exit code, signal, and last seen error to allow engine users to handle environment crash correctly in case of an unhandled exception.