### PR TITLE
fix: fixed flaky test

### DIFF
--- a/packages/electron-commons/test/initializers/electron-node.spec.ts
+++ b/packages/electron-commons/test/initializers/electron-node.spec.ts
@@ -6,6 +6,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import type { IOType } from 'child_process';
 import { deferred } from 'promise-assist';
+import { platform } from 'os';
 import testFeature, { serverEnv } from '../test-project/test-feature.feature';
 
 const { expect } = chai;
@@ -18,7 +19,7 @@ const setupRunningEnv = async ({
     handleUncaught,
     stdio = 'ignore',
 }: {
-    errorMode?: 'exception' | 'exit' | 'promiseReject' | 'out-of-memory';
+    errorMode?: 'exception' | 'exit' | 'promiseReject' | 'out-of-memory' | 'no-error';
     handleUncaught?: boolean;
     stdio?: IOType;
 } = {}) => {
@@ -55,33 +56,42 @@ const setupRunningEnv = async ({
 };
 
 describe('onDisconnectHandler for node environment initializer', () => {
-    const expectedProcessExitDetails: ProcessExitDetails = {
+    const expectedErrorResult: ProcessExitDetails = {
         exitCode: 1,
         signal: null,
         errorMessage: '',
     };
 
+    // windows does not support signals, so process termination
+    // results in `exitCode: 1` instead of `signal: 'SIGTERM'` for win32 platform
+    const expectedTerminationResult: ProcessExitDetails = {
+        exitCode: platform() === 'win32' ? 1 : null,
+        signal: platform() === 'win32' ? null : 'SIGTERM',
+        errorMessage: '',
+    };
+
     describe('without own uncaughtException handling', () => {
         it('should catch on dispose of env', async () => {
-            const { dispose, exitPromise } = await setupRunningEnv();
+            const { dispose, exitPromise } = await setupRunningEnv({ errorMode: 'no-error' });
 
             dispose();
 
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedTerminationResult);
         });
+
         it('should catch on env exit intentionally', async () => {
             const { exitPromise } = await setupRunningEnv({ errorMode: 'exit' });
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedErrorResult);
         });
         it('should catch on env throwing uncaught exception', async () => {
             const { exitPromise } = await setupRunningEnv({ errorMode: 'exception' });
 
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedErrorResult);
         });
         it('should catch on env unhandled promise rejection', async () => {
             const { exitPromise } = await setupRunningEnv({ errorMode: 'promiseReject' });
 
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedErrorResult);
         });
         it('should expose error when env throwing uncaught exception', async () => {
             const { exitPromise } = await setupRunningEnv({ errorMode: 'exception', stdio: 'pipe' });
@@ -92,25 +102,25 @@ describe('onDisconnectHandler for node environment initializer', () => {
     describe('with own uncaughtException handling', () => {
         const handleUncaught = true;
         it('should catch on dispose of env', async () => {
-            const { dispose, exitPromise } = await setupRunningEnv({ handleUncaught });
+            const { dispose, exitPromise } = await setupRunningEnv({ handleUncaught, errorMode: 'no-error' });
 
             dispose();
 
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedTerminationResult);
         });
         it('should catch on env exit intentionally', async () => {
             const { exitPromise } = await setupRunningEnv({ errorMode: 'exit', handleUncaught });
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedErrorResult);
         });
         it('should catch on env throwing uncaught exception', async () => {
             const { exitPromise } = await setupRunningEnv({ errorMode: 'exception', handleUncaught });
 
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedErrorResult);
         });
         it('should catch on env unhandled promise rejection', async () => {
             const { exitPromise } = await setupRunningEnv({ errorMode: 'promiseReject', handleUncaught });
 
-            await expect(exitPromise).to.eventually.deep.eq(expectedProcessExitDetails);
+            await expect(exitPromise).to.eventually.deep.eq(expectedErrorResult);
         });
     });
 });


### PR DESCRIPTION
The issue with test was that in fact, that test was not checking disposing. Because we are not passing `errorMode` from that test (it is undefined), feature is initialized with default config value for `errorMode` which is `exit`. This makes feature to do `process.exit(1)`.
So, there was a race condition between test that was disposing env and a feature that was doing process.exit(1).

the fix is to pass `no-error` for `errorMode`. in this case, feature will not crash a process and it will lasts.

also note that for windows there is no signal support, so I calculating expected result based on platform where test is running