### PR TITLE
feat: added workerthread environment type support

### DIFF
--- a/packages/core/src/com/types.ts
+++ b/packages/core/src/com/types.ts
@@ -7,6 +7,7 @@ export type EnvironmentTypes =
     | 'window'
     | 'iframe'
     | 'webworker'
+    | 'workerthread'
     | 'node'
     | 'context'
     | 'electron-renderer'

--- a/packages/electron-commons/package.json
+++ b/packages/electron-commons/package.json
@@ -17,7 +17,8 @@
     "tree-kill": "^1.2.2"
   },
   "devDependencies": {
-    "@fixture/disconnecting-env": "1.0.0"
+    "@fixture/disconnecting-env": "1.0.0",
+    "@fixture/worker-thread": "1.0.0"
   },
   "files": [
     "dist",

--- a/packages/electron-commons/test-kit/setup-running-node-env.ts
+++ b/packages/electron-commons/test-kit/setup-running-node-env.ts
@@ -7,6 +7,7 @@ import { initializeNodeEnvironment, ProcessExitDetails } from '@wixc3/engine-ele
 import { findFeatures } from '@wixc3/engine-scripts';
 
 const nodeEntryPath = require.resolve('@wixc3/engine-electron-commons/node-entry');
+const workerThreadEntryPath = require.resolve('@wixc3/engine-runtime-node/worker-thread-entry');
 
 export interface SetupRunningEnvOptions {
     featurePath: string;
@@ -33,6 +34,7 @@ export const setupRunningNodeEnv = async ({
             basePath: featurePath,
             outputPath: fs.join(featurePath, 'dist-app'),
             nodeEntryPath,
+            workerThreadEntryPath,
             config: config ?? [],
             features: Array.from(features.entries()),
         },

--- a/packages/electron-commons/test-kit/tsconfig.json
+++ b/packages/electron-commons/test-kit/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../../scripts/src"
+    },
+    {
+      "path": "../../../test-fixtures/worker-thread/src"
     }
   ]
 }

--- a/packages/electron-commons/test/tsconfig.json
+++ b/packages/electron-commons/test/tsconfig.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "../../../test-fixtures/disconnecting-env/src"
+    },
+    {
+      "path": "../../../test-fixtures/worker-thread/src"
     }
   ]
 }

--- a/packages/electron-commons/test/worker-thread.spec.ts
+++ b/packages/electron-commons/test/worker-thread.spec.ts
@@ -1,0 +1,35 @@
+import fs from '@file-services/node';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import workerThreadFeature, { serverEnv } from '@fixture/worker-thread/dist/worker-thread.feature';
+
+import { setupRunningNodeEnv } from '../test-kit/setup-running-node-env';
+
+chai.use(chaiAsPromised);
+
+const featurePath = fs.dirname(require.resolve('@fixture/worker-thread/package.json'));
+
+const setupRunningEnv = (featureId: string) =>
+    setupRunningNodeEnv({
+        featurePath,
+        featureId,
+        env: serverEnv,
+    });
+
+describe('workerthread environment type', () => {
+    it('initializes and exposes API', async () => {
+        const { exitPromise } = await setupRunningEnv(workerThreadFeature.id);
+
+        const exitResult = await exitPromise;
+
+        expect(exitResult.exitCode).to.eql(0);
+    });
+    it('initializes multi workerthread environment and exposes API', async () => {
+        const { exitPromise } = await setupRunningEnv(`${workerThreadFeature.id}/multi`);
+
+        const exitResult = await exitPromise;
+
+        expect(exitResult.exitCode).to.eql(0);
+    });
+});

--- a/packages/electron-host/src/start-electron-env.ts
+++ b/packages/electron-host/src/start-electron-env.ts
@@ -15,6 +15,7 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import runtimeArgumentsProvider from './runtime-arguments-provider';
 
 const nodeEntryPath = require.resolve('@wixc3/engine-electron-commons/node-entry');
+const workerThreadEntryPath = require.resolve('@wixc3/engine-electron-commons/worker-thread-entry');
 
 export interface ElectronEnvParams {
     basePath: string;
@@ -73,6 +74,7 @@ export async function runElectronEnv({
             outputPath,
             configName,
             nodeEntryPath,
+            workerThreadEntryPath,
             devtools,
             devport,
             features: Array.from(features.entries()),

--- a/packages/electron-host/src/types.ts
+++ b/packages/electron-host/src/types.ts
@@ -1,7 +1,7 @@
 import type { Environment } from '@wixc3/engine-core';
 import type { IEngineRuntimeArguments } from '@wixc3/engine-runtime-node';
 
-export interface IRunOptions extends Omit<IEngineRuntimeArguments, 'nodeEntryPath'> {
+export interface IRunOptions extends Omit<IEngineRuntimeArguments, 'nodeEntryPath' | 'workerThreadEntryPath'> {
     devport: number;
     devtools?: boolean;
     env: Environment;

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -21,7 +21,8 @@
     "!dist/test",
     "src",
     "!*/tsconfig.{json,tsbuildinfo}",
-    "templates"
+    "templates",
+    "worker-thread-entry.js"
   ],
   "license": "MIT",
   "publishConfig": {

--- a/packages/runtime-node/src/index.ts
+++ b/packages/runtime-node/src/index.ts
@@ -10,3 +10,5 @@ export * from './launch-http-server';
 export * from './parse-cli-arguments';
 export * from './get-application-metadata';
 export * from './import-modules';
+export * from './worker-thread-initializer';
+export * from './worker-thread-host';

--- a/packages/runtime-node/src/types.ts
+++ b/packages/runtime-node/src/types.ts
@@ -146,6 +146,7 @@ export interface IEngineRuntimeArguments {
     configName?: string;
     devport?: number;
     nodeEntryPath: string;
+    workerThreadEntryPath: string;
     features: [featureName: string, featureDefinition: Required<IStaticFeatureDefinition>][];
     config: TopLevelConfig;
     requiredModules?: string[];

--- a/packages/runtime-node/src/worker-thread-entry.ts
+++ b/packages/runtime-node/src/worker-thread-entry.ts
@@ -1,0 +1,63 @@
+import { COM } from '@wixc3/engine-core';
+import { parentPort } from 'node:worker_threads';
+import { importModules } from './import-modules';
+
+import { runNodeEnvironment } from './node-environment';
+import { isWorkerThreadEnvStartupMessage } from './types';
+import { WorkerThreadHost } from './worker-thread-host';
+
+const messageHandler = async (message: unknown) => {
+    if (isWorkerThreadEnvStartupMessage(message)) {
+        if (parentPort === null) {
+            throw new Error('this file should be executed in `worker_thread` context');
+        }
+
+        const {
+            requiredModules,
+            basePath,
+            environmentName,
+            config,
+            environmentContextName,
+            featureName,
+            features,
+            parentEnvName,
+            env,
+        } = message.runOptions;
+        if (requiredModules) {
+            await importModules(basePath, requiredModules);
+        }
+
+        const host = new WorkerThreadHost(parentPort);
+
+        config.push(
+            COM.use({
+                config: {
+                    connectedEnvironments: {
+                        [parentEnvName]: {
+                            id: parentEnvName,
+                            host,
+                        },
+                    },
+                },
+            })
+        );
+
+        await runNodeEnvironment({
+            env,
+            featureName,
+            features,
+            config,
+            host,
+            name: environmentName,
+            type: 'workerthread',
+            childEnvName: environmentContextName,
+        });
+    }
+};
+
+if (parentPort !== null) {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    parentPort.once('message', messageHandler);
+} else {
+    throw new Error('this file should be executed in `worker_thread` context');
+}

--- a/packages/runtime-node/src/worker-thread-host.ts
+++ b/packages/runtime-node/src/worker-thread-host.ts
@@ -1,0 +1,33 @@
+import { MessagePort, Worker } from 'node:worker_threads';
+
+import { BaseHost, Message } from '@wixc3/engine-core';
+
+export class WorkerThreadHost extends BaseHost {
+    constructor(private host: Worker | MessagePort) {
+        super();
+        host.on('message', this.onMessage);
+    }
+
+    public addEventListener(type: 'message', handler: (event: { data: any }) => void): void {
+        const handlers = this.handlers.get(type);
+        if (!handlers) {
+            this.handlers.set(type, new Set([handler]));
+        } else {
+            handlers.add(handler);
+        }
+
+        this.host.addListener(type, handler);
+    }
+
+    public removeEventListener(type: 'message', handler: (event: { data: any }) => void): void {
+        this.host.removeListener(type, handler);
+    }
+
+    public postMessage(data: Message): void {
+        this.host.postMessage(data);
+    }
+
+    private onMessage: (...args: any[]) => void = (message) => {
+        this.emitMessageHandlers(message);
+    };
+}

--- a/packages/runtime-node/src/worker-thread-initializer.ts
+++ b/packages/runtime-node/src/worker-thread-initializer.ts
@@ -1,0 +1,58 @@
+import { Worker } from 'node:worker_threads';
+
+import { COM, InitializerOptions } from '@wixc3/engine-core';
+
+import { WorkerThreadHost } from './worker-thread-host';
+import type { IWorkerThreadEnvStartupMessage } from './types';
+import { getApplicationMetaData } from './get-application-metadata';
+
+export async function workerThreadInitializer({ communication, env }: InitializerOptions) {
+    const isSingleton = env.endpointType === 'single';
+    const instanceId = isSingleton ? env.env : communication.generateEnvInstanceID(env.env);
+    const envReady = communication.envReady(instanceId);
+
+    const { workerThreadEntryPath, requiredModules, basePath, config, featureName, features } =
+        await getApplicationMetaData(communication);
+
+    const worker = new Worker(workerThreadEntryPath, {
+        workerData: {
+            name: instanceId,
+        },
+    });
+
+    const host = new WorkerThreadHost(worker);
+    communication.registerEnv(instanceId, host);
+    communication.registerMessageHandler(host);
+
+    const runOptions = {
+        requiredModules,
+        basePath,
+        environmentName: instanceId,
+        /**
+         * configuration contains data that can not be serialized to worker communication channel.
+         * in the configuration of COM feature there is LOCAL_ENVIRONMENT_INITIALIZER_ENV_ID
+         * environment info that is needed when node env wants to start new node env.
+         * this is not a case for workerthread, so ignoring that config here
+         */
+        config: config.filter(([featureId]) => featureId !== COM.id),
+        featureName,
+        features,
+        parentEnvName: communication.getEnvironmentName(),
+        env,
+    };
+
+    worker.postMessage({
+        id: 'workerThreadStartupOptions',
+        runOptions,
+    } as IWorkerThreadEnvStartupMessage);
+
+    await envReady;
+
+    return {
+        id: instanceId,
+        dispose: async () => {
+            await worker.terminate();
+            communication.clearEnvironment(instanceId);
+        },
+    };
+}

--- a/packages/runtime-node/worker-thread-entry.js
+++ b/packages/runtime-node/worker-thread-entry.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/worker-thread-entry');

--- a/packages/scripts/src/utils/environments.ts
+++ b/packages/scripts/src/utils/environments.ts
@@ -27,6 +27,7 @@ export function getResolvedEnvironments({
     const electronRendererEnvs = new Map<string, IResolvedEnvironment>();
     const nodeEnvs = new Map<string, IResolvedEnvironment>();
     const electronMainEnvs = new Map<string, IResolvedEnvironment>();
+    const workerThreadEnvs = new Map<string, IResolvedEnvironment>();
 
     const resolvedContexts = findAllEnvironments
         ? getPossibleContexts(features)
@@ -46,6 +47,8 @@ export function getResolvedEnvironments({
                 addEnv(nodeEnvs, env);
             } else if (type === 'electron-main') {
                 addEnv(electronMainEnvs, env);
+            } else if (type === 'workerthread') {
+                addEnv(workerThreadEnvs, env);
             } else {
                 throw new Error(`unknown environment type: ${type}`);
             }

--- a/test-fixtures/worker-thread/package.json
+++ b/test-fixtures/worker-thread/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@fixture/worker-thread",
+  "version": "1.0.0",
+  "main": "dist/entry.js",
+  "scripts": {},
+  "dependencies": {
+    "@wixc3/engine-core": "^33.2.0",
+    "@wixc3/engine-runtime-node": "^33.2.0"
+  },
+  "license": "unlicensed",
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "private": true,
+  "author": "Wix.com"
+}

--- a/test-fixtures/worker-thread/src/multi.feature.ts
+++ b/test-fixtures/worker-thread/src/multi.feature.ts
@@ -1,0 +1,16 @@
+import { Feature, Environment, COM, Service, Config } from '@wixc3/engine-core';
+import type { MultiWorkerEcho } from './multi.worker.env';
+
+export const serverEnv = new Environment('server', 'node', 'single');
+export const workerEnv = new Environment('worker', 'workerthread', 'multi');
+
+export default new Feature({
+    id: 'multi',
+    api: {
+        multiWorkerEcho: Service.withType<MultiWorkerEcho>().defineEntity(workerEnv).allowRemoteAccess(),
+        workerResponseConfig: Config.withType<{ response: string }>().defineEntity({
+            response: 'pong',
+        }),
+    },
+    dependencies: [COM.asDependency],
+});

--- a/test-fixtures/worker-thread/src/multi.server.env.ts
+++ b/test-fixtures/worker-thread/src/multi.server.env.ts
@@ -1,0 +1,33 @@
+import { workerThreadInitializer } from '@wixc3/engine-runtime-node';
+import multiFeature, { serverEnv, workerEnv } from './multi.feature';
+
+const workersCount = 3;
+
+multiFeature.setup(serverEnv, ({ run, multiWorkerEcho, workerResponseConfig }, { COM: { communication } }) => {
+    run(async () => {
+        const workerEnvs = await Promise.all(
+            new Array(workersCount).fill(undefined).map(() =>
+                workerThreadInitializer({
+                    communication,
+                    env: workerEnv,
+                })
+            )
+        );
+
+        let exitCode = 0;
+        for (const workerEnv of workerEnvs) {
+            const workerEchoService = multiWorkerEcho.get({ id: workerEnv.id });
+            const response = await workerEchoService.ping();
+
+            if (response !== workerResponseConfig.response) {
+                exitCode = 1;
+            }
+        }
+
+        for (const { dispose } of workerEnvs) {
+            await dispose();
+        }
+
+        process.exit(exitCode);
+    });
+});

--- a/test-fixtures/worker-thread/src/multi.worker.env.ts
+++ b/test-fixtures/worker-thread/src/multi.worker.env.ts
@@ -1,0 +1,15 @@
+import multiFeature, { workerEnv } from './multi.feature';
+
+export interface MultiWorkerEcho {
+    ping: () => string;
+}
+
+multiFeature.setup(workerEnv, ({ workerResponseConfig: { response } }) => {
+    return {
+        multiWorkerEcho: {
+            ping: () => {
+                return response;
+            },
+        },
+    };
+});

--- a/test-fixtures/worker-thread/src/tsconfig.json
+++ b/test-fixtures/worker-thread/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [{ "path": "../../../packages/core/src" }, { "path": "../../../packages/core-node/src" }]
+}

--- a/test-fixtures/worker-thread/src/worker-thread.feature.ts
+++ b/test-fixtures/worker-thread/src/worker-thread.feature.ts
@@ -1,0 +1,17 @@
+import { Feature, Environment, COM, Service, Config } from '@wixc3/engine-core';
+import type { WorkerEcho } from './worker-thread.worker.env';
+
+export const serverEnv = new Environment('server', 'node', 'single');
+
+export const workerEnv = new Environment('worker', 'workerthread', 'single');
+
+export default new Feature({
+    id: 'worker-thread',
+    api: {
+        workerEcho: Service.withType<WorkerEcho>().defineEntity(workerEnv).allowRemoteAccess(),
+        workerResponseConfig: Config.withType<{ response: string }>().defineEntity({
+            response: 'pong',
+        }),
+    },
+    dependencies: [COM.asDependency],
+});

--- a/test-fixtures/worker-thread/src/worker-thread.server.env.ts
+++ b/test-fixtures/worker-thread/src/worker-thread.server.env.ts
@@ -1,0 +1,21 @@
+import { workerThreadInitializer } from '@wixc3/engine-runtime-node';
+import workerThreadFeature, { serverEnv, workerEnv } from './worker-thread.feature';
+
+workerThreadFeature.setup(serverEnv, ({ run, workerEcho, workerResponseConfig }, { COM: { communication } }) => {
+    run(async () => {
+        const { dispose: disposeWorker } = await workerThreadInitializer({
+            communication,
+            env: workerEnv,
+        });
+
+        const response = await workerEcho.ping();
+
+        await disposeWorker();
+
+        if (response === workerResponseConfig.response) {
+            process.exit(0);
+        } else {
+            process.exit(1);
+        }
+    });
+});

--- a/test-fixtures/worker-thread/src/worker-thread.worker.env.ts
+++ b/test-fixtures/worker-thread/src/worker-thread.worker.env.ts
@@ -1,0 +1,15 @@
+import workerThreadFeature, { workerEnv } from './worker-thread.feature';
+
+export interface WorkerEcho {
+    ping: () => string;
+}
+
+workerThreadFeature.setup(workerEnv, ({ workerResponseConfig: { response } }) => {
+    return {
+        workerEcho: {
+            ping: () => {
+                return response;
+            },
+        },
+    };
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,6 +60,7 @@
     { "path": "./test-fixtures/with-iframe/src" },
     { "path": "./test-fixtures/workspace/packages/a/src" },
     { "path": "./test-fixtures/workspace/packages/b/src" },
-    { "path": "./test-fixtures/disconnecting-env/src" }
+    { "path": "./test-fixtures/disconnecting-env/src" },
+    { "path": "./test-fixtures/worker-thread/src" }
   ]
 }


### PR DESCRIPTION
- `workerthread` env type
- `workerthread` env initializer
- `workerthread` entrypoint
- tests to verify we can create new worker env for both `single` and `multi` modes and call its' API