### PR TITLE
refactor(electron-host): remove redundant listener

### DIFF
--- a/packages/electron-host/src/start-electron-env.ts
+++ b/packages/electron-host/src/start-electron-env.ts
@@ -1,5 +1,5 @@
 import fs from '@file-services/node';
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, ipcMain } from 'electron';
 
 import { BaseHost, Environment, RuntimeEngine, TopLevelConfig } from '@wixc3/engine-core';
 import { IEngineRuntimeArguments } from '@wixc3/engine-core-node';
@@ -105,23 +105,6 @@ export async function runElectronEnv({
         config,
         options: [...runOptions.entries()],
         env,
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    app.on('window-all-closed', async () => {
-        // Don't quit between closing one window and immediately opening another.
-        await new Promise((res) => setTimeout(res, 0));
-
-        if (BrowserWindow.getAllWindows().length === 0) {
-            try {
-                await runningEnvironment.dispose();
-            } catch (e) {
-                process.exitCode = 1;
-                // eslint-disable-next-line no-console
-                console.error(e);
-            }
-            app.quit();
-        }
     });
 
     return runningEnvironment;


### PR DESCRIPTION
Remove `window-all-closed` listener that manually close the app when all windows are closed