### PR TITLE
fix: fix static feature definitions in dev server mode

### DIFF
--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -98,15 +98,19 @@ devServerFeature.setup(
                 featureName,
                 providedFeatureDiscoveryRoot ?? featureDiscoveryRoot
             );
+
+            const staticFeatures = new Map(
+                [...features].map(([featureName, feature]) => [featureName, feature.toJSON()])
+            );
+
             //Node environment manager, need to add self to the topology, I thing starting the server and the NEM should happen in the setup and not in the run
             // So potential dependencies can rely on them in the topology
-
             application.setNodeEnvManager(
                 new NodeEnvironmentsManager(
                     socketServer,
                     {
                         configurations,
-                        features,
+                        features: staticFeatures,
                         defaultRuntimeOptions,
                         bundlePath: application.outputPath,
                         port: actualPort,


### PR DESCRIPTION
Fix dev server mode to convert analyzed features to static feature definition to avoid issues with bypassing types as Symbol as a message between envs