### PR TITLE
fix(test-kit): grant `clipboard-read` permissions for `playwright`

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -274,7 +274,11 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
                 configName: newConfigName,
                 queryParams,
             });
-            const browserContext = await browser.newContext(browserContextOptions);
+            const permissions = browserContextOptions?.permissions ?? [];
+            const browserContext = await browser.newContext({
+                ...browserContextOptions,
+                permissions: [...permissions, 'clipboard-read'],
+            });
             disposeAfter(() => browserContext.close(), WITH_FEATURE_DISPOSABLES);
 
             browserContext.on('page', onPageCreation);


### PR DESCRIPTION
Needed in order to allow `playwright` retrieve the text stored in clipboard when running a feature in test mode