### PR TITLE
fix(com): use unique message ids

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -98,7 +98,7 @@ export class Communication {
         this.registerMessageHandler(host);
         this.registerEnv(id, host);
         this.environments['*'] = { id, host };
-        this.messageIdPrefix = `c_${this.getEnvironmentId()}_${Math.random().toString(36)}`;
+        this.messageIdPrefix = `c_${this.getEnvironmentId()}_${Math.random().toString(36).slice(2)}`;
         this.post(this.getPostEndpoint(host), {
             type: 'ready',
             from: id,

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -98,7 +98,7 @@ export class Communication {
         this.registerMessageHandler(host);
         this.registerEnv(id, host);
         this.environments['*'] = { id, host };
-        this.messageIdPrefix = `c_${this.getEnvironmentId()}_${Math.random()}`;
+        this.messageIdPrefix = `c_${this.getEnvironmentId()}_${Math.random().toString(36)}`;
         this.post(this.getPostEndpoint(host), {
             type: 'ready',
             from: id,

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -83,7 +83,7 @@ export class Communication {
     private messageHandlers = new WeakMap<Target, (options: { data: null | Message }) => void>();
     private disposeListeners = new Set<(envId: string) => void>();
     private callbackToEnvMapping = new Map<string, string>();
-
+    private messageIdPrefix: string;
     constructor(
         host: Target,
         id: string,
@@ -98,7 +98,7 @@ export class Communication {
         this.registerMessageHandler(host);
         this.registerEnv(id, host);
         this.environments['*'] = { id, host };
-
+        this.messageIdPrefix = `c_${this.getEnvironmentId()}_${Math.random()}`;
         this.post(this.getPostEndpoint(host), {
             type: 'ready',
             from: id,
@@ -252,7 +252,9 @@ export class Communication {
         forwardingChain: string[]
     ): Promise<unknown> {
         return new Promise<void>((res, rej) => {
-            const callbackId = !serviceComConfig[method]?.emitOnly ? this.idsCounter.next('c') : undefined;
+            const callbackId = !serviceComConfig[method]?.emitOnly
+                ? this.idsCounter.next(this.messageIdPrefix)
+                : undefined;
 
             if (this.isListenCall(args) || serviceComConfig[method]?.removeAllListeners) {
                 this.addOrRemoveListener(
@@ -390,7 +392,7 @@ export class Communication {
                     handlerId,
                     this.createHandlerIdPrefix({ from: this.rootEnvId, to: instanceId })
                 ),
-                callbackId: this.idsCounter.next('c'),
+                callbackId: this.idsCounter.next(this.messageIdPrefix),
                 origin: this.rootEnvId,
                 handlerId,
                 forwardingChain: [],
@@ -538,7 +540,7 @@ export class Communication {
     }
 
     private async forwardListenMessage(message: ListenMessage): Promise<void> {
-        const callbackId = this.idsCounter.next('c');
+        const callbackId = this.idsCounter.next(this.messageIdPrefix);
 
         const data = await new Promise<void>((res, rej) => {
             const handlerId = message.handlerId;
@@ -777,7 +779,7 @@ export class Communication {
     }
 
     private async forwardUnlisten(message: UnListenMessage) {
-        const callbackId = this.idsCounter.next('c');
+        const callbackId = this.idsCounter.next(this.messageIdPrefix);
         const { method, api } = this.parseHandlerId(message.handlerId, this.createHandlerIdPrefix(message));
 
         const data = await new Promise<void>((res, rej) =>


### PR DESCRIPTION
Communication forward message functionality can accidentally resolve wrong pending callback record if callbackId is the same. Since previously call and callbacks ids were just counters `c0` `c1` `c2` - the chances of it happening are high at the startup.

p.s. forward message functionality seemed wrong but math checks out. Just callback ids should be more unique. Environment id is nor improving uniqueness, but come in handy for debugging. 

fixes issue with workers not starting sometimes