### PR TITLE
chore!: getRunningFeature uses disposeAfter to engine feature by default

### DIFF
--- a/examples/file-server/src/test/file-server.unit.ts
+++ b/examples/file-server/src/test/file-server.unit.ts
@@ -1,16 +1,12 @@
 import { getRunningFeature } from '@wixc3/engine-test-kit';
-import { createDisposables } from '@wixc3/create-disposables';
 
 import Feature, { server } from '../feature/file-server.feature';
 import { expect } from 'chai';
 import fs from '@file-services/node';
 
 describe('file-server Processing env test', () => {
-    const disposables = createDisposables();
-    afterEach(disposables.dispose);
     it('reads directory', async () => {
         const {
-            engine,
             runningApi: { remoteFiles },
         } = await getRunningFeature({
             featureName: 'file-server',
@@ -20,7 +16,6 @@ describe('file-server Processing env test', () => {
             },
             feature: Feature,
         });
-        disposables.add(engine.shutdown);
 
         const remoteFile = remoteFiles.readFile(fs.basename(__filename));
         expect(remoteFile).to.eq(fs.readFileSync(__filename, 'utf8'));

--- a/examples/multi-env/src/test/file-server.unit.ts
+++ b/examples/multi-env/src/test/file-server.unit.ts
@@ -1,14 +1,10 @@
 import { getRunningFeature } from '@wixc3/engine-test-kit';
-import { createDisposables } from '@wixc3/create-disposables';
 import Feature, { processingEnv } from '../feature/multi-env.feature';
 import { expect } from 'chai';
 
 describe('multi-env Processing env test', () => {
-    const disposables = createDisposables();
-    afterEach(disposables.dispose);
-
     it('echos from node env', async () => {
-        const { engine, runningApi } = await getRunningFeature({
+        const { runningApi } = await getRunningFeature({
             featureName: 'multi-env/test-node',
             env: processingEnv,
             runtimeOptions: {
@@ -16,7 +12,6 @@ describe('multi-env Processing env test', () => {
             },
             feature: Feature,
         });
-        disposables.add(engine.shutdown);
 
         const message = runningApi.echoService.echo('text');
         expect(message).to.eq('node env says text');

--- a/packages/test-kit/src/run-environment.ts
+++ b/packages/test-kit/src/run-environment.ts
@@ -21,12 +21,13 @@ import {
 } from '@wixc3/engine-runtime-node';
 
 import {
+    ENGINE_CONFIG_FILE_NAME,
+    findFeatures,
+    evaluateConfig,
     EngineConfig,
     IFeatureDefinition,
-    evaluateConfig,
-    findFeatures,
-    ENGINE_CONFIG_FILE_NAME,
 } from '@wixc3/engine-scripts';
+import { disposeAfter } from '@wixc3/testing';
 
 const workerThreadEntryPath = require.resolve('@wixc3/engine-runtime-node/worker-thread-entry');
 
@@ -170,7 +171,8 @@ function locateEnvironment(
 }
 
 export async function getRunningFeature<F extends FeatureClass, ENV extends AnyEnvironment>(
-    options: RunningFeatureOptions<F, ENV>
+    options: RunningFeatureOptions<F, ENV>,
+    disposeAfterTest = true
 ): Promise<{
     runningApi: Running<F, ENV>;
     engine: RuntimeEngine;
@@ -180,6 +182,12 @@ export async function getRunningFeature<F extends FeatureClass, ENV extends AnyE
     const { feature } = options;
     const engine = await runEngineEnvironment(options);
     const { api } = engine.get(feature);
+
+    if (disposeAfterTest) {
+        disposeAfter(engine.shutdown, {
+            name: `engine shutdown for ${options.featureName}`,
+        });
+    }
     return {
         runningApi: api,
         engine,

--- a/packages/test-kit/test/run-environment.unit.ts
+++ b/packages/test-kit/test/run-environment.unit.ts
@@ -4,22 +4,17 @@ import fs from '@file-services/node';
 
 import { getRunningFeature } from '../src/run-environment';
 import workerThreadFeature, { serverEnv } from '@fixture/worker-thread/dist/worker-thread.feature';
-import { createDisposables } from '@wixc3/create-disposables';
 
 const featurePath = fs.dirname(require.resolve('@fixture/worker-thread/package.json'));
 
 describe('runs environment', () => {
-    const disposables = createDisposables();
-    afterEach(disposables.dispose);
-
     it('runs environment with workerthread support', async () => {
-        const { dispose, runningApi } = await getRunningFeature({
+        const { runningApi } = await getRunningFeature({
             env: serverEnv,
             feature: workerThreadFeature,
             featureName: workerThreadFeature.id,
             basePath: featurePath,
         });
-        disposables.add(dispose);
 
         const result = await runningApi.workerService.initAndCallWorkerEcho('hello');
         expect(result).to.equal('hello from worker');


### PR DESCRIPTION
## Review Notes
The meat of the change is at `packages/test-kit/src/run-environment.ts` - changing getRunningFeature to shut down the feature by default once the test is done
 