### PR TITLE
test: execute all tests from dist

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,6 +1,4 @@
 module.exports = {
-    require: ['@ts-tools/node/r'],
-    extension: ['js', 'json', 'ts', 'tsx'],
     colors: true,
     timeout: 10000,
     'enable-source-maps': true,

--- a/engine.config.js
+++ b/engine.config.js
@@ -2,6 +2,5 @@
  * @type {import('@wixc3/engine-scripts').EngineConfig}
  */
 module.exports = {
-    require: ['@ts-tools/node/r'],
     featureDiscoveryRoot: 'dist',
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@file-services/types": "^7.4.0",
     "@stylable/cli": "^5.13.0",
     "@stylable/webpack-plugin": "^5.13.0",
-    "@ts-tools/node": "^4.0.0",
     "@ts-tools/webpack-loader": "^4.0.0",
     "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build:stylable": "stc --srcDir src --outDir dist --stcss --no-cjs --unsr",
-    "test": "mocha \"test/**/*.unit.ts?(x)\""
+    "test": "mocha \"dist/test/**/*.unit.js\""
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/engineer/package.json
+++ b/packages/engineer/package.json
@@ -8,7 +8,7 @@
     "engineer": "./bin/engineer.js"
   },
   "scripts": {
-    "test": "mocha \"test/**/*.unit.ts?(x)\""
+    "test": "mocha \"dist/test/**/*.unit.js\""
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "mocha \"test/**/*.unit.ts?(x)\""
+    "test": "mocha \"dist/test/**/*.unit.js\""
   },
   "dependencies": {
     "@wixc3/common": "^10.0.0",

--- a/packages/runtime-node/test/node-com.unit.ts
+++ b/packages/runtime-node/test/node-com.unit.ts
@@ -1,5 +1,4 @@
 import { fork } from 'child_process';
-import { join } from 'path';
 import type { Socket } from 'net';
 import { safeListeningHttpServer } from 'create-listening-server';
 import io from 'socket.io';
@@ -301,10 +300,7 @@ describe('IPC communication', () => {
     it('communication with forked process', async () => {
         const mainHost = new BaseHost();
         const communication = new Communication(mainHost, 'main');
-        const forked = fork(join(__dirname, 'process-entry.ts'), [], {
-            execArgv: '-r @ts-tools/node/r'.split(' '),
-            cwd: process.cwd(),
-        });
+        const forked = fork(require.resolve('./process-entry'));
         disposables.add(() => forked.kill());
         const host = new IPCHost(forked);
         communication.registerEnv('process', host);
@@ -322,10 +318,7 @@ describe('IPC communication', () => {
     it('handles forked process closing', async () => {
         const mainHost = new BaseHost();
         const communication = new Communication(mainHost, 'main');
-        const forked = fork(join(__dirname, 'process-entry.ts'), [], {
-            execArgv: '-r @ts-tools/node/r'.split(' '),
-            cwd: process.cwd(),
-        });
+        const forked = fork(require.resolve('./process-entry'));
         const host = new IPCHost(forked);
         communication.registerEnv('process', host);
         communication.registerMessageHandler(host);

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "mocha \"test/**/*.unit.ts?(x)\""
+    "test": "mocha \"dist/test/**/*.unit.js\""
   },
   "peerDependencies": {
     "html-webpack-plugin": "^4.0.0 || ^5.0.0",

--- a/packages/scripts/test/merge.unit.ts
+++ b/packages/scripts/test/merge.unit.ts
@@ -1,5 +1,5 @@
 import { SetMultiMap } from '@wixc3/patterns';
-import { mergeAll, mergeResults } from '../src/analyze-feature/merge';
+import { mergeAll, mergeResults } from '@wixc3/engine-scripts/dist/analyze-feature/merge';
 import { expect } from 'chai';
 
 describe('mergeAll', () => {

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "mocha \"test/**/*.unit.ts?(x)\""
+    "test": "mocha \"dist/test/**/*.unit.js\""
   },
   "peerDependencies": {
     "playwright-core": ">=1.0.0"

--- a/packages/test-kit/test/run-environment.unit.ts
+++ b/packages/test-kit/test/run-environment.unit.ts
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
-
 import fs from '@file-services/node';
-
-import { getRunningFeature } from '../src/run-environment';
+import { getRunningFeature } from '@wixc3/engine-test-kit';
 import workerThreadFeature, { serverEnv } from '@fixture/worker-thread/dist/worker-thread.feature';
 
 const featurePath = fs.dirname(require.resolve('@fixture/worker-thread/package.json'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "./packages/runtime-node/test" },
 
     { "path": "./packages/dashboard/src" },
+    { "path": "./packages/dashboard/test" },
 
     { "path": "./packages/electron/src" },
     { "path": "./packages/electron-commons/src" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,14 +896,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@ts-tools/node@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@ts-tools/node/-/node-4.0.0.tgz#0dc58bee311c9f9392f45ae97ea863d9069302c7"
-  integrity sha512-Xk4iBoahkxSi47/z10yhtJ6E8VjDVsGXMuB33tQB4+KRymdrEFCk4LNdllwbhQ61HAH3PWOknF6PeVf2YOsLZA==
-  dependencies:
-    "@ts-tools/transpile" "^4.0.0"
-    source-map-support "^0.5.21"
-
 "@ts-tools/transpile@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@ts-tools/transpile/-/transpile-4.0.0.tgz#62d27e8ece39e53fd9e4c8597aa2718475537394"
@@ -7213,7 +7205,7 @@ source-map-loader@^4.0.1:
     iconv-lite "^0.6.3"
     source-map-js "^1.0.2"
 
-source-map-support@^0.5.19, source-map-support@^0.5.21, source-map-support@~0.5.20:
+source-map-support@^0.5.19, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==


### PR DESCRIPTION
- some packages already ran from dist. make sure all do
- will allow running all from root with --parallel flag
- get rid of @ts-tools/node (cjs-only) to pave the way for moduleResolution: node16
- above will also allow to dynamically import esm from cts files and improve handling of native esm in existing mechanism