### PR TITLE
chore: getRunningFeature optionally disposal timeout arg, default 10s

### DIFF
--- a/packages/test-kit/src/run-environment.ts
+++ b/packages/test-kit/src/run-environment.ts
@@ -167,9 +167,13 @@ function locateEnvironment(
     return undefined;
 }
 
+/**
+ * get a running feature with no browser environment
+ * @param disposeAfterTestTimeout if false, will not dispose the engine after the test
+ */
 export async function getRunningFeature<F extends FeatureClass, ENV extends AnyEnvironment>(
     options: RunningFeatureOptions<F, ENV>,
-    disposeAfterTest = true
+    disposeAfterTestTimeout: false | number = 10_000
 ): Promise<{
     runningApi: Running<F, ENV>;
     engine: RuntimeEngine;
@@ -180,9 +184,10 @@ export async function getRunningFeature<F extends FeatureClass, ENV extends AnyE
     const engine = await runEngineEnvironment(options);
     const { api } = engine.get(feature);
 
-    if (disposeAfterTest) {
+    if (disposeAfterTestTimeout) {
         disposeAfter(engine.shutdown, {
             name: `engine shutdown for ${options.featureName}`,
+            timeout: disposeAfterTestTimeout,
         });
     }
     return {


### PR DESCRIPTION
previous behavior: getRunningFeature would run engine.shutdown after each test with a set timeout of 1 sec

new behaviour:
getRunningFeature takes the disposeAfterTestTimeout arg (prev boolean disposeAfterTest)
which can set the disposal timeout, new default 10sec instead of 1