### PR TITLE
fix(dashboard): avoid rendering "0"  to ui

### DIFF
--- a/packages/dashboard/src/components/sidebar/sidebar.tsx
+++ b/packages/dashboard/src/components/sidebar/sidebar.tsx
@@ -7,7 +7,7 @@ export const Sidebar: FC = () => {
 
     return (
         <section className={classes.leftBar}>
-            {serverState.featuresWithRunningNodeEnvs.length && (
+            {!!serverState.featuresWithRunningNodeEnvs.length && (
                 <div>
                     <div className={classes.title}>Running Features:</div>
                     {serverState.featuresWithRunningNodeEnvs.map(([f, c]) => (


### PR DESCRIPTION
when there's no node envs running