### PR TITLE
refactor: replace memoize-one with own impl

### DIFF
--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -12,7 +12,6 @@
     "@wixc3/patterns": "^13.2.0",
     "create-listening-server": "^2.1.0",
     "express": "^4.18.2",
-    "memoize-one": "^6.0.0",
     "minimist": "^1.2.8",
     "socket.io": "^4.7.2"
   },

--- a/packages/runtime-node/src/core-node/create-application-metadata-provider.ts
+++ b/packages/runtime-node/src/core-node/create-application-metadata-provider.ts
@@ -1,6 +1,5 @@
 import { Communication } from '@wixc3/engine-core';
 import { createDisposables } from '@wixc3/patterns';
-import memoizeOne from 'memoize-one';
 import { metadataApiToken, type MetadataCollectionAPI } from '../types.js';
 import { ENGINE_ROOT_ENVIRONMENT_ID, METADATA_PROVIDER_ENV_ID } from './constants.js';
 
@@ -14,6 +13,17 @@ export function createMetadataProvider(com: Communication) {
     return {
         getMetadata: () => metadataPromise,
         dispose: disposeCommunication,
+    };
+}
+
+function memoizeOne<A extends object, R>(fn: (arg: A) => R): (arg: A) => R {
+    const argToRes = new WeakMap<A, R>();
+    return (arg: A) => {
+        if (argToRes.has(arg)) {
+            return argToRes.get(arg)!;
+        }
+        const res = fn(arg);
+        return res;
     };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5307,11 +5307,6 @@ memfs@^3.4.12:
   dependencies:
     fs-monkey "^1.0.4"
 
-memoize-one@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
-  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
-
 meow@^8.1.2:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"


### PR DESCRIPTION
package is the only dep that gives us trouble with typescript in node16 module/moduleResolution, so remove it