### PR TITLE
infra(core): bundle from dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@file-services/types": "^8.1.1",
     "@stylable/cli": "^5.15.1",
     "@stylable/webpack-plugin": "^5.15.1",
-    "@ts-tools/webpack-loader": "^5.0.1",
     "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",
     "@types/cors": "^2.8.13",

--- a/packages/core/scripts/bundle.js
+++ b/packages/core/scripts/bundle.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 const path = require('path');
 const baseWebpackConfig = require('../../../webpack.config');
 
-const entryPath = require.resolve('../src/index.ts');
+const entryPath = require.resolve('../dist/index.js');
 const outputPath = path.join(__dirname, '../dist/umd');
 
 function getConfigForMode(mode) {

--- a/packages/core/webpack.config.test.js
+++ b/packages/core/webpack.config.test.js
@@ -11,9 +11,6 @@ module.exports = {
     output: {
         filename: '[name].web.js',
     },
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json'],
-    },
     plugins: [
         new HtmlWebpackPlugin({
             filename: `iframe.html`,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,9 +4,6 @@ const { StylableWebpackPlugin } = require('@stylable/webpack-plugin');
 module.exports = {
     context: __dirname,
     devtool: 'source-map',
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json'],
-    },
     module: {
         rules: [
             {
@@ -14,10 +11,6 @@ module.exports = {
                 enforce: 'pre',
                 loader: 'source-map-loader',
                 exclude: /node_modules/,
-            },
-            {
-                test: /\.tsx?$/,
-                loader: '@ts-tools/webpack-loader',
             },
             {
                 test: /\.(png|jpg|gif|svg)$/i,

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,18 +903,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@ts-tools/transpile@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@ts-tools/transpile/-/transpile-5.0.1.tgz#04bba2e7cbfe411f15473681bc6e4b91b03a056a"
-  integrity sha512-+Qj+nvg4n/Bf2GHoMUoNC7VI6jAFezHpwe6SegJLSZA8ARdFjtpKAg87Q95FsZpgsmNwlRmJTD4hp9MaWkxEgA==
-
-"@ts-tools/webpack-loader@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@ts-tools/webpack-loader/-/webpack-loader-5.0.1.tgz#1551d2f3885872d792a3494a3c58defd787ce661"
-  integrity sha512-GeACyTpW1lHhRCms4uktH8BcgHm4eMv2SS61PyMgEJdlG2N25aH0WL9kiZ4KTQXqbhauSns4VZOhENn+fwrRdg==
-  dependencies:
-    "@ts-tools/transpile" "^5.0.1"
-
 "@tufjs/canonical-json@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz#eade9fd1f537993bc1f0949f3aea276ecc4fab31"


### PR DESCRIPTION
- we have a bundle task that occurs right before publishing (prepack).
- make sure it uses dist to support upcoming esm migration.
- allows us to remove ts-tools altogether.