### PR TITLE
feat: use worker thread for fresh configs

### DIFF
--- a/packages/core/src/runtime-configurations.ts
+++ b/packages/core/src/runtime-configurations.ts
@@ -6,9 +6,9 @@ declare global {
     }
 }
 
-export type ConfigModule = {
+export interface ConfigModule {
     default: TopLevelConfig;
-};
+}
 
 export type ConfigLoader = () => Promise<ConfigModule[]>;
 

--- a/packages/electron-scripts/src/engine-helpers.ts
+++ b/packages/electron-scripts/src/engine-helpers.ts
@@ -1,4 +1,4 @@
-import type { TopLevelConfig } from '@wixc3/engine-core';
+import type { ConfigModule, TopLevelConfig } from '@wixc3/engine-core';
 import type { IConfigDefinition } from '@wixc3/engine-runtime-node';
 import type { SetMultiMap } from '@wixc3/patterns';
 
@@ -16,7 +16,7 @@ export function getConfig(
     for (const { filePath, envName: configEnvName } of configs) {
         if (!configEnvName || configEnvName === envName) {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            config.push(...(require(filePath) as { default: TopLevelConfig }).default);
+            config.push(...(require(filePath) as ConfigModule).default);
         }
     }
 

--- a/packages/runtime-node/src/node-environments-manager.ts
+++ b/packages/runtime-node/src/node-environments-manager.ts
@@ -2,6 +2,7 @@ import {
     BaseHost,
     COM,
     Communication,
+    ConfigModule,
     type ConfigEnvironmentRecord,
     type Message,
     type ReadyMessage,
@@ -461,7 +462,7 @@ export class NodeEnvironmentsManager {
                     config.push(...definition);
                 } else {
                     try {
-                        config.push(...((await import(definition.filePath)) as { default: TopLevelConfig }).default);
+                        config.push(...((await import(definition.filePath)) as ConfigModule).default);
                     } catch (e) {
                         console.error(
                             new Error(

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -22,7 +22,6 @@
     "cors": "^2.8.5",
     "create-listening-server": "^2.1.0",
     "express": "^4.18.2",
-    "import-fresh": "^3.3.0",
     "semver": "^7.5.4",
     "socket.io": "^4.7.2",
     "type-fest": "^4.2.0"

--- a/packages/scripts/src/import-fresh.ts
+++ b/packages/scripts/src/import-fresh.ts
@@ -1,0 +1,21 @@
+import { once } from 'node:events';
+import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads';
+
+/**
+ * Imports a module and returns its exports. The module is executed in a new worker thread.
+ * This ensures that the module and its dependencies are completely reloaded.
+ * @param filePath - The path to the module to import.
+ * @returns A Promise that resolves to the exports of the imported module.
+ */
+export async function importFresh(filePath: string): Promise<unknown> {
+    const worker = new Worker(__filename, { workerData: filePath });
+    const [imported] = await once(worker, 'message');
+    await worker.terminate();
+    return imported;
+}
+
+if (!isMainThread && typeof workerData === 'string') {
+    import(workerData)
+        .then((moduleExports) => parentPort?.postMessage(moduleExports))
+        .catch((e) => parentPort?.postMessage('error', e));
+}

--- a/packages/scripts/src/load-node-environment.ts
+++ b/packages/scripts/src/load-node-environment.ts
@@ -1,5 +1,5 @@
 import type { SetMultiMap } from '@wixc3/patterns';
-import type { TopLevelConfig } from '@wixc3/engine-core';
+import type { ConfigModule, TopLevelConfig } from '@wixc3/engine-core';
 import type { IConfigDefinition } from '@wixc3/engine-runtime-node';
 
 export function evaluateConfig(
@@ -16,7 +16,7 @@ export function evaluateConfig(
     for (const { filePath, envName: configEnvName } of configs) {
         if (!configEnvName || configEnvName === envName) {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            config.push(...(require(filePath) as { default: TopLevelConfig }).default);
+            config.push(...(require(filePath) as ConfigModule).default);
         }
     }
 

--- a/packages/scripts/src/top-level-config-loader.ts
+++ b/packages/scripts/src/top-level-config-loader.ts
@@ -1,68 +1,29 @@
-export interface PartialWebpackLoaderContext {
-    query: string;
-    resourcePath: string;
-    rootContext: string;
-    addDependency(filePath: string): void;
-    emitFile(filePath: string, contents: string, sourcemap: boolean): void;
+import { ConfigModule } from '@wixc3/engine-core';
+import type webpack from 'webpack';
+import { importFresh } from './import-fresh.js';
+
+export interface TopLevelConfigLoaderOptions {
+    scopedName: string;
+    envName?: string;
+    configLoaderModuleName: string;
 }
 
-export default function topLevelConfigLoader(this: PartialWebpackLoaderContext) {
-    const params = new URLSearchParams(this.query.slice(1));
-
-    const fileName = params.get('scopedName');
-    const envName = params.get('envName');
-    const configLoaderModuleName = params.get('configLoaderModuleName');
-    const cachedModule = require.cache[this.resourcePath];
-    const imported = requireDeepHack(this.resourcePath, this.rootContext);
-    if (cachedModule) {
-        walkChildModules(cachedModule, ({ filename }) => {
-            if (!filename.includes('node_modules') && filename.includes(this.rootContext)) {
-                this.addDependency(filename);
-            }
-        });
+const topLevelConfigLoader: webpack.LoaderDefinition<TopLevelConfigLoaderOptions> = async function () {
+    const { scopedName, envName, configLoaderModuleName } = this.getOptions();
+    if (!scopedName) {
+        throw new Error('scopedName is required');
+    } else if (!configLoaderModuleName) {
+        throw new Error('configLoaderModuleName is required');
     }
-    const importedString = JSON.stringify(imported);
+    const { default: topLevelConfig } = (await importFresh(this.resourcePath)) as ConfigModule;
+    const configFileName = envName ? `${scopedName}.${envName}` : scopedName;
+    const configPath = `configs/${configFileName}.json`;
 
-    const configFileName = envName ? `${fileName!}.${envName}` : fileName;
-    const configPath = `configs/${configFileName!}.json`;
+    this.emitFile(configPath, JSON.stringify(topLevelConfig));
 
-    this.emitFile(configPath, importedString, false);
+    return `import { loadConfig } from "${configLoaderModuleName}";
+const fetchResult = loadConfig("${scopedName}", "${envName}");
+export default fetchResult`;
+};
 
-    return `
-    import { loadConfig } from '${configLoaderModuleName!}';
-    const fetchResult = loadConfig('${fileName!}', '${envName!}');
-    export default fetchResult`;
-}
-
-function walkChildModules(nodeJsModule: NodeModule, visitor: (module: NodeModule) => void, registryCache = new Set()) {
-    if (!nodeJsModule || registryCache.has(nodeJsModule)) {
-        return;
-    }
-    registryCache.add(nodeJsModule);
-    visitor(nodeJsModule);
-    if (nodeJsModule && nodeJsModule.children) {
-        nodeJsModule.children.forEach((cm) => {
-            walkChildModules(cm, visitor, registryCache);
-        });
-    }
-}
-
-/**
- * This all method is a hack that allows fresh requiring modules
- */
-function requireDeepHack(resourcePath: string, rootContext: string): unknown {
-    const previousCache: Record<string, NodeModule> = {};
-    walkChildModules(require.cache[resourcePath]!, ({ filename }) => {
-        if (!filename.includes('node_modules') && filename.includes(rootContext)) {
-            previousCache[filename] = require.cache[filename]!;
-            delete require.cache[filename];
-        }
-    });
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const imported = require(resourcePath) as { default?: any };
-    for (const [key, nodeModule] of Object.entries(previousCache)) {
-        require.cache[key] = nodeModule;
-    }
-
-    return imported.default ?? imported;
-}
+export default topLevelConfigLoader;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4399,7 +4399,7 @@ ignore@^5.0.4, ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-import-fresh@^3.2.1, import-fresh@^3.3.0:
+import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==


### PR DESCRIPTION
- rewrote top-level-config-loader in the process, adding more exact types and validations
- new approach is not coupled to the module system itself