### PR TITLE
fix(electron): add missing ./dist/hosts entry

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./dist/hosts": "./dist/hosts/index.js",
     "./package.json": "./package.json"
   },
   "peerDependencies": {


### PR DESCRIPTION
we currently use it downstream, so allow it for now