### PR TITLE
fix(electron-scripts): add /dist/commands export

### DIFF
--- a/packages/electron-scripts/package.json
+++ b/packages/electron-scripts/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./dist/commands": "./dist/commands/index.js",
     "./package.json": "./package.json"
   },
   "bin": {


### PR DESCRIPTION
used by downstream, so support it for now