### PR TITLE
fix(electron-scripts): use commander in CLI

### DIFF
--- a/packages/electron-scripts/package.json
+++ b/packages/electron-scripts/package.json
@@ -27,7 +27,7 @@
     "@wixc3/engineer": "^40.0.4",
     "@wixc3/patterns": "^13.2.0",
     "@wixc3/resolve-directory-context": "^4.0.0",
-    "yargs": "^17.7.2"
+    "commander": "^11.0.0"
   },
   "files": [
     "bin",

--- a/packages/electron-scripts/src/cli.ts
+++ b/packages/electron-scripts/src/cli.ts
@@ -1,97 +1,54 @@
-import yargs from 'yargs';
-import { build, start } from './commands/index.js';
+import { Command } from 'commander';
 
-yargs()
-    .command('start', 'starts the electron application in dev mode', async (command) => {
-        const options = command
-            .option('featureName', {
-                alias: 'f',
-                type: 'string',
-                required: true,
-            })
-            .option('configName', {
-                alias: 'c',
-                type: 'string',
-            })
-            .option('envName', {
-                alias: 'e',
-                type: 'string',
-                demandOption: true,
-            })
-            .option('basePath', {
-                type: 'string',
-            })
-            .option('devtools', {
-                type: 'boolean',
-            })
-            .option('featureDiscoveryRoot', {
-                type: 'string',
-            })
-            .parseSync();
+process.on('unhandledRejection', reportProcessError);
+process.on('uncaughtException', reportProcessError);
 
-        await start({
-            ...options,
-        });
-    })
-    .command('build', 'builds the elecrton application', async (command) => {
-        const options = command
-            .option('featureName', {
-                alias: 'f',
-                type: 'string',
-                demandOption: true,
-            })
-            .option('configName', {
-                alias: 'c',
-                type: 'string',
-            })
-            .option('basePath', {
-                default: process.cwd(),
-            })
-            .option('outDir', {
-                default: 'dist',
-                describe: 'the directory to which the bundled and transpiled code will be saved (relative to basePath)',
-            })
-            .option('envName', {
-                alias: 'e',
-                type: 'string',
-                demandOption: true,
-                describe: 'The name of the electron main process environment',
-            })
-            .option('electronBuilderConfigFileName', {
-                describe: 'The name of the electrion builder config file (relative to basePath)',
-                default: 'electron-build.json',
-            })
-            .option('linux', {
-                type: 'boolean',
-                default: undefined,
-            })
-            .option('mac', {
-                type: 'boolean',
-                default: undefined,
-            })
-            .option('windows', {
-                type: 'boolean',
-                default: undefined,
-            })
-            .option('publish', {
-                type: 'string',
-            })
-            .option('featureDiscoveryRoot', {
-                type: 'string',
-            })
-            .option('eagerEntrypoint', {
-                type: 'boolean',
-                default: false,
-            })
-            .parseSync();
+const program = new Command();
 
-        await build({
-            ...options,
-        });
-    })
-    .parseAsync()
-    .catch((e) => {
-        process.exitCode = 1;
-        // eslint-disable-next-line no-console
-        console.log(e);
+function createCommand(commandName: string): Command {
+    return program
+        .command(commandName)
+        .requiredOption('-f, --featureName <featureName>')
+        .option('-c, --configName <configName>')
+        .requiredOption('-e, --envName <envName>', 'The name of the electron main process environment')
+        .option('--basePath <basePath>', undefined, process.cwd())
+        .option('--featureDiscoveryRoot <featureDiscoveryRoot>')
+        .option('--singleFeature');
+}
+
+createCommand('start')
+    .description('starts the electron application in dev mode')
+    .option('--devtools')
+    .action(async (options) => {
+        const { start } = await import('./commands/start');
+        await start(options);
     });
+
+createCommand('build')
+    .description('builds the electron application')
+    .option(
+        '--outDir <outDir>',
+        'the directory to which the bundled and transpiled code will be saved (relative to basePath)',
+        'dist',
+    )
+    .option(
+        '--electronBuilderConfigFileName <electronBuilderConfigFileName>',
+        'The name of the electron builder config file (relative to basePath)',
+        'electron-build.json',
+    )
+    .option('--linux')
+    .option('--mac')
+    .option('--windows')
+    .option('--publish <publish>')
+    .option('--eagerEntrypoint')
+    .action(async (options) => {
+        const { build } = await import('./commands/build');
+        await build(options);
+    });
+
+program.parseAsync().catch(reportProcessError);
+
+function reportProcessError(error: unknown): void {
+    console.log(error);
+    process.exitCode = 1;
+}

--- a/packages/electron-scripts/src/commands/build.ts
+++ b/packages/electron-scripts/src/commands/build.ts
@@ -85,7 +85,7 @@ export async function build(options: IBuildCommandOptions): Promise<void> {
     } = options;
     const outputPath = fs.join(basePath, outDir);
     if (!isPublishValid(publish)) {
-        throw new Error(`publish value can be defined with the wollowing values: ${possiblePublishValues.join(',')}`);
+        throw new Error(`publish value can be defined with the following values: ${possiblePublishValues.join(',')}`);
     }
 
     if (requiredModules) {


### PR DESCRIPTION
yargs fails quitely and is not clear about how to compose commands with typed options