### PR TITLE
refactor(scripts): improve import-fresh esm compat

### DIFF
--- a/packages/scripts/src/config-middleware.ts
+++ b/packages/scripts/src/config-middleware.ts
@@ -1,4 +1,4 @@
-import { COM, type ConfigModule, type TopLevelConfig } from '@wixc3/engine-core';
+import { COM, type TopLevelConfig } from '@wixc3/engine-core';
 import type { IConfigDefinition, NodeEnvironmentsManager, TopLevelConfigProvider } from '@wixc3/engine-runtime-node';
 import type { SetMultiMap } from '@wixc3/patterns';
 import type express from 'express';
@@ -43,7 +43,7 @@ export function createLiveConfigsMiddleware(
                             if (envName === reqEnv || !envName) {
                                 const resolvedPath = require.resolve(filePath, { paths: [basePath] });
                                 try {
-                                    const { default: configValue } = (await importFresh(resolvedPath)) as ConfigModule;
+                                    const configValue = (await importFresh(resolvedPath)) as TopLevelConfig;
                                     config.push(...configValue);
                                 } catch (e) {
                                     console.error(

--- a/packages/scripts/src/import-fresh.ts
+++ b/packages/scripts/src/import-fresh.ts
@@ -2,22 +2,42 @@ import { once } from 'node:events';
 import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads';
 
 /**
- * Imports a module and returns its exports. The module is executed in a new worker thread.
- * This ensures that the module and its dependencies are completely reloaded.
+ * Imports a module and returns the value of a specific export.
+ * The module is executed in a new worker thread, which ensures that the module and
+ * its dependencies are completely reloaded.
+ *
  * @param filePath - The path to the module to import.
+ * @param exportSymbolName - name of the exported symbol to get the value of. defaults to `"default"`.
  * @returns A Promise that resolves to the exports of the imported module.
  */
-export async function importFresh(filePath: string): Promise<unknown> {
-    const worker = new Worker(__filename, { workerData: filePath });
+export async function importFresh(filePath: string, exportSymbolName = 'default'): Promise<unknown> {
+    const worker = new Worker(__filename, {
+        workerData: { filePath, exportSymbolName } satisfies ImportFreshWorkerData,
+    });
     const [imported] = await once(worker, 'message');
     await worker.terminate();
     return imported;
 }
 
-if (!isMainThread && typeof workerData === 'string') {
-    import(workerData)
-        .then((moduleExports) => parentPort?.postMessage(moduleExports))
+if (!isMainThread && isImportWorkerData(workerData)) {
+    const { filePath, exportSymbolName } = workerData;
+    import(filePath)
+        .then((moduleExports) => parentPort?.postMessage(moduleExports[exportSymbolName]))
         .catch((e) => {
             throw e;
         });
+}
+
+interface ImportFreshWorkerData {
+    filePath: string;
+    exportSymbolName: string;
+}
+
+function isImportWorkerData(value: unknown): value is ImportFreshWorkerData {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as ImportFreshWorkerData).filePath === 'string' &&
+        typeof (value as ImportFreshWorkerData).exportSymbolName === 'string'
+    );
 }

--- a/packages/scripts/src/top-level-config-loader.ts
+++ b/packages/scripts/src/top-level-config-loader.ts
@@ -1,4 +1,4 @@
-import type { ConfigModule } from '@wixc3/engine-core';
+import type { TopLevelConfig } from '@wixc3/engine-core';
 import type webpack from 'webpack';
 import { importFresh } from './import-fresh.js';
 
@@ -15,7 +15,7 @@ const topLevelConfigLoader: webpack.LoaderDefinition<TopLevelConfigLoaderOptions
     } else if (!configLoaderModuleName) {
         throw new Error('configLoaderModuleName is required');
     }
-    const { default: topLevelConfig } = (await importFresh(this.resourcePath)) as ConfigModule;
+    const topLevelConfig = (await importFresh(this.resourcePath)) as TopLevelConfig;
     const configFileName = envName ? `${scopedName}.${envName}` : scopedName;
     const configPath = `configs/${configFileName}.json`;
 


### PR DESCRIPTION
when moving to esm, the dynamic imports stays as-is, and gives us an runtime module value, which cannot be cloned across the threads. adjusted method to also accept an export symbol name, and default to the "default" export (as used by configs).