### PR TITLE
fix(with-feature): increase timeout of dispose suite level page

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -247,7 +247,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
 
     if (persist) {
         after('dispose suite level page', async function () {
-            this.timeout(10_000);
+            this.timeout(30_000);
             await disposables.dispose();
         });
         const disposables = new Disposables();


### PR DESCRIPTION
Fixing the issue of timeout exceeded when using the option `persist: true`.
Here is an exmaple of the issue that will be fixed:
https://github.com/wixplosives/codux/actions/runs/5966393026/job/16185936650