### PR TITLE
fix(with-feature): adjust suite level page timeout

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -247,7 +247,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}) {
 
     if (persist) {
         after('dispose suite level page', async function () {
-            this.timeout(30_000);
+            this.timeout(disposables.list().totalTimeout);
             await disposables.dispose();
         });
         const disposables = new Disposables();


### PR DESCRIPTION
Adjusting the mocha timeout to be the same as the disposables' timeout.