### PR TITLE
fix(scripts): correct case of misdetected type import

### DIFF
--- a/packages/scripts/src/utils/resolve-module-graph.ts
+++ b/packages/scripts/src/utils/resolve-module-graph.ts
@@ -83,7 +83,10 @@ function isTypeOnlyExports(node: ts.ExportDeclaration) {
 }
 
 function isTypeOnlyImport(node: ts.ImportDeclaration) {
-    return node.importClause?.isTypeOnly || hasOnlyTypeBindings(node.importClause?.namedBindings);
+    return (
+        node.importClause?.isTypeOnly ||
+        (node.importClause?.name == undefined && hasOnlyTypeBindings(node.importClause?.namedBindings))
+    );
 }
 
 function hasOnlyTypeBindings(bindings?: ts.NamedImportBindings | ts.NamedExportBindings) {


### PR DESCRIPTION
`import Package, { type A, type B } from 'package';` was detected as type-only and ignored