### PR TITLE
fix(engineer): apply conditions/require hooks to node

### DIFF
--- a/packages/electron-scripts/src/commands/start.ts
+++ b/packages/electron-scripts/src/commands/start.ts
@@ -54,7 +54,7 @@ export async function start({
         require: requiredModules,
         featureDiscoveryRoot: configFeatureDiscoveryRoot,
         extensions,
-        conditions,
+        buildConditions,
     } = (await getEngineConfig(basePath)) || {};
 
     const resolvedFeatureDiscoveryRoot = featureDiscoveryRoot ?? configFeatureDiscoveryRoot;
@@ -79,7 +79,7 @@ export async function start({
             fs,
             resolvedFeatureDiscoveryRoot,
             extensions,
-            conditions,
+            buildConditions,
         );
 
         const environments = getExportedEnvironments(features);

--- a/packages/engineer/bin/engineer.js
+++ b/packages/engineer/bin/engineer.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../dist/cli.js');
+require('../dist/cli-bootstrap.js');

--- a/packages/engineer/package.json
+++ b/packages/engineer/package.json
@@ -7,6 +7,7 @@
     ".": "./dist/index.js",
     "./bin/engineer": "./bin/engineer.js",
     "./gui-feature": "./dist/feature/gui.feature.js",
+    "./dist/cli": "./dist/cli.js",
     "./dist/feature-dependency-graph": "./dist/feature-dependency-graph.js",
     "./package.json": "./package.json"
   },

--- a/packages/engineer/src/application-proxy-service.ts
+++ b/packages/engineer/src/application-proxy-service.ts
@@ -33,12 +33,12 @@ export class TargetApplication extends Application {
         featureName?: string,
         featureDiscoveryRoot?: string,
         extensions?: string[],
-        conditions?: string[],
+        extraConditions?: string[],
     ) {
         const { features, configurations, packages } = await super.analyzeFeatures(
             featureDiscoveryRoot,
             extensions,
-            conditions,
+            extraConditions,
         );
         if (singleFeature && featureName) {
             this.filterByFeatureName(features, featureName);

--- a/packages/engineer/src/cli-bootstrap.ts
+++ b/packages/engineer/src/cli-bootstrap.ts
@@ -1,0 +1,17 @@
+import { resolveExecArgv } from '@wixc3/engine-scripts';
+import { once } from 'node:events';
+import { Worker } from 'node:worker_threads';
+
+(async () => {
+    const basePath = process.cwd();
+    const execArgv = await resolveExecArgv(basePath);
+
+    const worker = new Worker(require.resolve('./cli.js'), {
+        argv: process.argv.slice(2),
+        execArgv,
+    });
+    await once(worker, 'exit');
+})().catch((err) => {
+    console.log(err);
+    process.exit(1);
+});

--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -71,7 +71,7 @@ devServerFeature.setup(
                 serveStatic = [],
                 featureDiscoveryRoot,
                 extensions,
-                conditions,
+                buildConditions,
             } = engineConfig ?? {};
             await application.importModules(requiredPaths);
             const resolvedSocketServerOptions: Partial<io.ServerOptions> = {
@@ -99,7 +99,7 @@ devServerFeature.setup(
                 featureName,
                 providedFeatureDiscoveryRoot ?? featureDiscoveryRoot,
                 extensions,
-                conditions,
+                buildConditions,
             );
 
             const staticFeatures = new Map(

--- a/packages/engineer/src/utils.ts
+++ b/packages/engineer/src/utils.ts
@@ -43,7 +43,7 @@ export async function startDevServer(options: IStartOptions): Promise<{
         undefined,
         undefined,
         engineCnf.extensions,
-        engineCnf.conditions,
+        engineCnf.buildConditions,
     );
 
     const engine = await runNodeEnvironment({

--- a/packages/scripts/src/analyze-feature/find-features.ts
+++ b/packages/scripts/src/analyze-feature/find-features.ts
@@ -13,7 +13,7 @@ export async function findFeatures(
     fs: IFileSystemSync,
     featureDiscoveryRoot = '.',
     extensions?: string[],
-    conditions?: string[],
+    extraConditions?: string[],
 ): Promise<FoundFeatures> {
     const packages = childPackagesFromContext(resolveDirectoryContext(path, fs));
     const paths = packages.map(({ directoryPath }) => fs.join(directoryPath, featureDiscoveryRoot));
@@ -24,8 +24,8 @@ export async function findFeatures(
 
     return {
         ...mergeResults(
-            await loadFeaturesFromPaths(features, fs, packages, undefined, extensions, conditions),
-            await loadFeaturesFromPaths(fixtures, fs, packages, undefined, extensions, conditions),
+            await loadFeaturesFromPaths(features, fs, packages, undefined, extensions, extraConditions),
+            await loadFeaturesFromPaths(fixtures, fs, packages, undefined, extensions, extraConditions),
         ),
         packages,
     };

--- a/packages/scripts/src/analyze-feature/load-features-from-paths.ts
+++ b/packages/scripts/src/analyze-feature/load-features-from-paths.ts
@@ -33,9 +33,9 @@ export async function loadFeaturesFromPaths(
     packages: INpmPackage[] = [],
     override = {},
     extensions?: string[],
-    conditions?: string[],
+    extraConditions?: string[],
 ) {
-    const imported = getImportedFeatures(roots, fs, extensions, conditions);
+    const imported = getImportedFeatures(roots, fs, extensions, extraConditions);
 
     // this is our actual starting point. we now have a list of directories which contain
     // feature/env/config files, both in our repo and from node_modules.
@@ -166,14 +166,14 @@ function getImportedFeatures(
     roots: DirFeatures,
     fs: IFileSystemSync,
     extensions?: string[],
-    conditions?: string[],
+    extraConditions?: string[],
 ): DirFeatures {
     const imported = {
         dirs: new Set<string>(),
         files: new Set<string>(),
     };
     // find all imported feature files from initial ones
-    const filePathsInGraph = Object.keys(resolveModuleGraph(Array.from(roots.files), extensions, conditions));
+    const filePathsInGraph = Object.keys(resolveModuleGraph(Array.from(roots.files), extensions, extraConditions));
     const featureFilePaths = filePathsInGraph.filter((filePath) => isFeatureFile(fs.basename(filePath)));
     for (const filePath of featureFilePaths) {
         addNew(roots.files, imported.files, filePath);

--- a/packages/scripts/src/application/application.ts
+++ b/packages/scripts/src/application/application.ts
@@ -69,7 +69,7 @@ export class Application {
         const analyzed = await this.analyzeFeatures(
             buildOptions.featureDiscoveryRoot ?? config.featureDiscoveryRoot,
             config.extensions,
-            config.conditions,
+            config.buildConditions,
         );
 
         if (buildOptions.singleFeature && buildOptions.featureName) {
@@ -472,12 +472,12 @@ export class Application {
         return { compiler };
     }
 
-    protected async analyzeFeatures(featureDiscoveryRoot = '.', extensions?: string[], conditions?: string[]) {
+    protected async analyzeFeatures(featureDiscoveryRoot = '.', extensions?: string[], extraConditions?: string[]) {
         const { basePath } = this;
 
         console.time(`Analyzing Features`);
         // const packages = childPackagesFromContext(resolveDirectoryContext(basePath, fs));
-        const featuresAndConfigs = await findFeatures(basePath, fs, featureDiscoveryRoot, extensions, conditions);
+        const featuresAndConfigs = await findFeatures(basePath, fs, featureDiscoveryRoot, extensions, extraConditions);
         console.timeEnd('Analyzing Features');
         return featuresAndConfigs;
     }

--- a/packages/scripts/src/import-fresh.ts
+++ b/packages/scripts/src/import-fresh.ts
@@ -13,6 +13,8 @@ import { Worker, isMainThread, parentPort, workerData } from 'node:worker_thread
 export async function importFresh(filePath: string, exportSymbolName = 'default'): Promise<unknown> {
     const worker = new Worker(__filename, {
         workerData: { filePath, exportSymbolName } satisfies ImportFreshWorkerData,
+        // doesn't seem to inherit two levels deep (Worker from Worker)
+        execArgv: [...process.execArgv],
     });
     const [imported] = await once(worker, 'message');
     await worker.terminate();

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -7,6 +7,7 @@ export * from './engine-router.js';
 export * from './feature-generator/index.js';
 export * from './load-feature-directory.js';
 export * from './load-node-environment.js';
+export * from './resolve-exec-argv.js';
 export * from './run-environment.js';
 export * from './types.js';
 export * from './utils/index.js';

--- a/packages/scripts/src/resolve-exec-argv.ts
+++ b/packages/scripts/src/resolve-exec-argv.ts
@@ -1,0 +1,23 @@
+import { nodeFs as fs } from '@file-services/node';
+import type { EngineConfig } from './types';
+import { ENGINE_CONFIG_FILE_NAME } from './build-constants';
+
+export async function resolveExecArgv(basePath: string) {
+    const engineConfig = await fs.promises.findClosestFile(basePath, ENGINE_CONFIG_FILE_NAME);
+    const { default: config } = (engineConfig ? await import(engineConfig) : {}) as { default?: EngineConfig };
+
+    const execArgv = [...process.execArgv];
+    if (config?.require) {
+        for (const pathToRequire of config.require) {
+            // https://nodejs.org/api/cli.html#-r---require-module
+            execArgv.push('-r', pathToRequire);
+        }
+    }
+    if (config?.buildConditions) {
+        for (const condition of config.buildConditions) {
+            // https://nodejs.org/api/cli.html#-c-condition---conditionscondition
+            execArgv.push('-C', condition);
+        }
+    }
+    return execArgv;
+}

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -76,8 +76,11 @@ export interface EngineConfig {
     favicon?: string;
     nodeEnvironmentsMode?: LaunchEnvironmentMode;
 
-    /** @default ["browser", "import", "require"] */
-    conditions?: string[];
+    /**
+     * extra resolver conditions to add while building project.
+     * used for finding features and running in dev time
+     */
+    buildConditions?: string[];
 
     /** @default [".js", ".json"] */
     extensions?: string[];

--- a/packages/test-kit/src/forked-process-application.ts
+++ b/packages/test-kit/src/forked-process-application.ts
@@ -1,5 +1,10 @@
 import { isProcessMessage, type PerformanceMetrics, type ProcessMessageId } from '@wixc3/engine-runtime-node';
-import type { IFeatureMessagePayload, IFeatureTarget, IPortMessage } from '@wixc3/engine-scripts';
+import {
+    resolveExecArgv,
+    type IFeatureMessagePayload,
+    type IFeatureTarget,
+    type IPortMessage,
+} from '@wixc3/engine-scripts';
 import { ChildProcess, fork } from 'node:child_process';
 import type { IExecutableApplication } from './types.js';
 
@@ -17,7 +22,6 @@ export class ForkedProcessApplication implements IExecutableApplication {
         if (this.port) {
             throw new Error('The server is already running.');
         }
-        const execArgv = process.argv.some((arg) => arg.startsWith('--inspect')) ? ['--inspect'] : [];
 
         const args = ['start', '--engineerEntry', 'engineer/managed'];
 
@@ -25,6 +29,7 @@ export class ForkedProcessApplication implements IExecutableApplication {
             args.push('--featureDiscoveryRoot');
             args.push(this.featureDiscoveryRoot);
         }
+        const execArgv = await resolveExecArgv(this.basePath);
 
         this.engineStartProcess = fork(this.cliEntry, args, {
             stdio: 'inherit',

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -14,7 +14,7 @@ import { validateBrowser } from './supported-browsers.js';
 import type { IExecutableApplication } from './types.js';
 import { ensureTracePath } from './utils/index.js';
 
-const cliEntry = require.resolve('@wixc3/engineer/bin/engineer');
+const cliEntry = require.resolve('@wixc3/engineer/dist/cli');
 
 export interface IFeatureExecutionOptions {
     /**


### PR DESCRIPTION
when engine.config.js specifies "require" and/or "buildConditions", these are now applied to the engineer process and any worker/child process it starts.