### PR TITLE
fix(scripts): avoid removing specifier extension

### DIFF
--- a/packages/scripts/src/utils/paths.ts
+++ b/packages/scripts/src/utils/paths.ts
@@ -8,9 +8,7 @@ export function getFilePathInPackage(
     isRelativeRequest: boolean,
 ) {
     const relativeFilePath = fs.relative(context, filePath);
-    const relativeRequest = fs
-        .join(fs.dirname(relativeFilePath), fs.basename(relativeFilePath, fs.extname(relativeFilePath)))
-        .replace(/\\/g, '/');
+    const relativeRequest = fs.join(fs.dirname(relativeFilePath), fs.basename(relativeFilePath)).replace(/\\/g, '/');
     return isRelativeRequest
         ? relativeRequest.startsWith('.')
             ? relativeRequest

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -105,7 +105,7 @@ describe('Application', function () {
                 const featureDefinition = manifest.features.find(([featureName]) => featureName === 'engine-single/x');
                 expect(featureDefinition).to.not.eq(undefined);
                 const [, { filePath }] = featureDefinition!;
-                expect(filePath).to.eq('../dist/feature/x.feature');
+                expect(filePath).to.eq('../dist/feature/x.feature.js');
             });
 
             it('uses sourcesRoot when building to the output path which is inside package directory', async () => {
@@ -122,7 +122,7 @@ describe('Application', function () {
                 const featureDefinition = manifest.features.find(([featureName]) => featureName === 'engine-single/x');
                 expect(featureDefinition).to.not.eq(undefined);
                 const [, { filePath }] = featureDefinition!;
-                expect(filePath).to.eq('../lib/dist/feature/x.feature');
+                expect(filePath).to.eq('../lib/dist/feature/x.feature.js');
             });
 
             it('maps to own feature request to package requests if output path outside package directory', async () => {
@@ -139,7 +139,7 @@ describe('Application', function () {
                 const featureDefinition = manifest.features.find(([featureName]) => featureName === 'engine-single/x');
                 expect(featureDefinition).to.not.eq(undefined);
                 const [, { filePath }] = featureDefinition!;
-                expect(filePath).to.eq('@fixture/engine-single-feature/dist/feature/x.feature');
+                expect(filePath).to.eq('@fixture/engine-single-feature/dist/feature/x.feature.js');
             });
 
             it('uses package requests when output path is outside package path', async () => {
@@ -157,7 +157,7 @@ describe('Application', function () {
                 const featureDefinition = manifest.features.find(([featureName]) => featureName === 'engine-single/x');
                 expect(featureDefinition).to.not.eq(undefined);
                 const [, { filePath }] = featureDefinition!;
-                expect(filePath).to.eq('@fixture/engine-single-feature/lib/dist/feature/x.feature');
+                expect(filePath).to.eq('@fixture/engine-single-feature/lib/dist/feature/x.feature.js');
             });
         });
     });


### PR DESCRIPTION
to better support running against sources, where the specifier might end with .ts or .tsx.

for both .ts and .js, we don't mind the specifier being more specifiic. it's making it easier to resolve.