### PR TITLE
fix(electron-scripts): use absolute path for module

### DIFF
--- a/packages/electron-scripts/src/commands/start.ts
+++ b/packages/electron-scripts/src/commands/start.ts
@@ -103,7 +103,8 @@ export async function start({
         let NODE_OPTIONS = '--enable-source-maps';
         if (requiredModules) {
             for (const requiredModule of requiredModules) {
-                NODE_OPTIONS += ` --require=${requiredModule}`;
+                const resolvedRequiredModule = require.resolve(requiredModule, { paths: [basePath] });
+                NODE_OPTIONS += ` --require=${resolvedRequiredModule}`;
             }
         }
         if (buildConditions) {


### PR DESCRIPTION
just in case env starts with a different cwd