### PR TITLE
fix(engineer): fail process when worker fails

### DIFF
--- a/packages/engineer/src/cli-bootstrap.ts
+++ b/packages/engineer/src/cli-bootstrap.ts
@@ -10,7 +10,8 @@ import { Worker } from 'node:worker_threads';
         argv: process.argv.slice(2),
         execArgv,
     });
-    await once(worker, 'exit');
+    const [code] = await once(worker, 'exit');
+    process.exit(code);
 })().catch((err) => {
     console.log(err);
     process.exit(1);


### PR DESCRIPTION
- ensure we await "exit" and fail when appropriate
- this regressed when we moved to using worker threads