### PR TITLE
feat: running is cjs

### DIFF
--- a/packages/engine-cli/bin/engine.js
+++ b/packages/engine-cli/bin/engine.js
@@ -1,3 +1,19 @@
 #!/usr/bin/env node
 
-require('../dist/cli.js');
+const { resolveExecArgv } = require('@wixc3/engine-scripts');
+const { once } = require('node:events');
+const { Worker } = require('node:worker_threads');
+
+(async () => {
+    const basePath = process.cwd();
+    const execArgv = await resolveExecArgv(basePath);
+    const worker = new Worker(require.resolve('../dist/cli.js'), {
+        argv: process.argv.slice(2),
+        execArgv,
+    });
+    const [code] = await once(worker, 'exit');
+    process.exit(code);
+})().catch((err) => {
+    console.log(err);
+    process.exit(1);
+});

--- a/packages/engine-cli/src/create-environments-build-configuration.ts
+++ b/packages/engine-cli/src/create-environments-build-configuration.ts
@@ -46,12 +46,13 @@ export function createEnvironmentsBuildConfiguration(options: CreateEnvBuildConf
     } = options;
 
     const mode = dev ? 'development' : 'production';
-    const jsOutExtension = '.mjs';
+    const jsOutExtension = '.js' as '.js' | '.mjs';
+    const nodeFormat = jsOutExtension === '.mjs' ? 'esm' : 'cjs';
     const webEntryPoints = new Map<string, string>();
     const nodeEntryPoints = new Map<string, string>([
         [
             `engine-environment-manager${jsOutExtension}`,
-            createNodeEnvironmentManagerEntrypoint({ features, configurations, mode, configName }),
+            createNodeEnvironmentManagerEntrypoint({ features, configurations, mode, configName }, nodeFormat),
         ],
     ]);
     const browserTargets = concatIterables(environments.webEnvs.values(), environments.workerEnvs.values());
@@ -145,6 +146,7 @@ export function createEnvironmentsBuildConfiguration(options: CreateEnvBuildConf
     const nodeConfig = {
         ...commonConfig,
         platform: 'node',
+        format: nodeFormat,
         outdir: join(outputPath, 'node'),
         plugins: [...commonConfig.plugins, dynamicEntryPlugin({ entryPoints: nodeEntryPoints, loader: 'js' })],
     } satisfies BuildOptions;

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -165,11 +165,18 @@ async function runDevServices({
 
     console.log(`Engine dev server listening on port ${port}`);
 
+    const managerPath = ['.js', '.mjs']
+        .map((ext) => fs.join(outputPath, 'node', `engine-environment-manager${ext}`))
+        .find(fs.existsSync);
+
+    if (!managerPath) {
+        throw new Error(`Could not find "engine-environment-manager" entrypoint in ${fs.join(outputPath, 'node')}`);
+    }
+
     // start node environment manager
     fork(
-        fs.join(outputPath, 'node/engine-environment-manager.mjs'),
+        managerPath,
         [`--applicationPath=${fs.join(outputPath, 'web')}`, `--feature=${featureName}`, `--config=${configName}`],
-
         {
             execArgv: process.execArgv.concat(['--watch']),
             stdio: 'inherit',

--- a/packages/runtime-node/src/node-env-manager.ts
+++ b/packages/runtime-node/src/node-env-manager.ts
@@ -1,9 +1,8 @@
 import { AnyEnvironment, BaseHost, Communication, ConfigModule, IRunOptions } from '@wixc3/engine-core';
 import { SetMultiMap } from '@wixc3/patterns';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import { WsServerHost } from './core-node/ws-node-host';
-import { dynamicImport } from './dynamic-import';
 import { resolveEnvironments } from './environments';
 import { launchEngineHttpServer } from './launch-http-server';
 import { IStaticFeatureDefinition } from './types';

--- a/packages/runtime-node/src/node-env-manager.ts
+++ b/packages/runtime-node/src/node-env-manager.ts
@@ -92,7 +92,8 @@ export class NodeEnvManager {
         return await Promise.all(
             configFiles.map(async (filePath) => {
                 try {
-                    const configModule = (await dynamicImport(pathToFileURL(filePath))).default as ConfigModule;
+                    // TODO: make it work in esm via injection 
+                    const configModule = (await require(filePath)).default as ConfigModule;
                     console.log(`[ENGINE]: loaded config file ${filePath} for env ${envName} successfully`);
                     return configModule.default ?? configModule;
                 } catch (e) {

--- a/packages/scripts/src/create-entrypoint.ts
+++ b/packages/scripts/src/create-entrypoint.ts
@@ -65,7 +65,7 @@ export interface LoadStatementArguments
 //#endregion
 
 //#region feature loaders generation
-export function createFeatureLoaders(
+export function createFeatureLoadersSourceCode(
     features: Iterable<IFeatureDefinition>,
     childEnvs: string[],
     env: IEnvironmentDescriptor,
@@ -73,20 +73,23 @@ export function createFeatureLoaders(
     featuresBundleName?: string,
     absImports?: boolean,
 ) {
-    return `new Map(Object.entries({\n${Array.from(features)
-        .map(
-            (args) =>
-                `    '${args.scopedName}': ${createLoaderInterface({
-                    ...args,
-                    childEnvs,
-                    loadStatement: dynamicImportStatement,
-                    eagerEntrypoint,
-                    absImports,
-                    env,
-                    featuresBundleName,
-                })}`,
-        )
-        .join(',\n')}\n}))`;
+    let entries = '[';
+
+    for (const feature of features) {
+        const loaderCode = createLoaderInterface({
+            ...feature,
+            childEnvs,
+            loadStatement: dynamicImportStatement,
+            eagerEntrypoint,
+            absImports,
+            env,
+            featuresBundleName,
+        });
+        entries += `['${feature.scopedName}', ${loaderCode}],`;
+    }
+
+    entries += ']';
+    return `new Map(${entries})`;
 }
 
 function loadEnvAndContextFiles({

--- a/packages/scripts/src/create-web-entrypoint.ts
+++ b/packages/scripts/src/create-web-entrypoint.ts
@@ -1,5 +1,5 @@
 import { Environment } from '@wixc3/engine-core';
-import { ICreateEntrypointsOptions, createConfigLoaders, createFeatureLoaders } from './create-entrypoint';
+import { ICreateEntrypointsOptions, createConfigLoaders, createFeatureLoadersSourceCode } from './create-entrypoint';
 
 const { stringify } = JSON;
 
@@ -36,7 +36,7 @@ export function createMainEntrypoint({
         loadConfigFileTemplate: webLoadConfigFileTemplate.bind(null, configLoaderModuleName),
     });
     const runtimePublicPath = handlePublicPathTemplate(publicPath, publicPathVariableName);
-    const featureLoaders = createFeatureLoaders(
+    const featureLoaders = createFeatureLoadersSourceCode(
         features.values(),
         childEnvs,
         env,


### PR DESCRIPTION
This PR focus on running our main project in the same mode (cjs)

It add support for running in both modes but currently uses `require` instead of import (only in the new node flow). 