### PR TITLE
fix: added reportError polyfil

### DIFF
--- a/packages/core/src/polyfills/report-error-polyfill.ts
+++ b/packages/core/src/polyfills/report-error-polyfill.ts
@@ -1,9 +1,12 @@
 import { reportError } from "../com";
 
 /**
- * hope this is single polyfill we need for now
- * in case if more will be added, we need to create some
- * better mechanism to handle polyfills
+ * This polyfill is not essential for the engine itself. But applications built
+ * on the engine may require this polyfill to correctly report initialization
+ * errors in older browsers.
+ * Ideally, the engine should offer a mechanism allowing applications to
+ * initialize necessary polyfills before the evaluation of feature files begins.
+ * But so far we only need this single polyfill.
  */
 if (globalThis.reportError === undefined) {
     globalThis.reportError = reportError;

--- a/packages/core/src/polyfills/report-error-polyfill.ts
+++ b/packages/core/src/polyfills/report-error-polyfill.ts
@@ -1,0 +1,10 @@
+import { reportError } from "../com";
+
+/**
+ * hope this is single polyfill we need for now
+ * in case if more will be added, we need to create some
+ * better mechanism to handle polyfills
+ */
+if (globalThis.reportError === undefined) {
+    globalThis.reportError = reportError;
+}

--- a/packages/core/src/runtime-main.ts
+++ b/packages/core/src/runtime-main.ts
@@ -1,3 +1,5 @@
+import "./polyfills/report-error-polyfill.js";
+
 import type { IRunOptions, TopLevelConfig } from './types.js';
 import type { AnyEnvironment } from './entities/index.js';
 import { FeatureLoadersRegistry, IFeatureLoader } from './run-engine-app.js';


### PR DESCRIPTION
Added reportError polyfill to allow applications and are using native `reportError` to execute feature setup.