### PR TITLE
refactor: try to simplify and remove module state from `createMetadataProvider`

### DIFF
--- a/packages/electron-node/src/initializers/node-process.ts
+++ b/packages/electron-node/src/initializers/node-process.ts
@@ -1,6 +1,6 @@
 import { type ActiveEnvironment, type EnvironmentInitializer } from '@wixc3/engine-core';
 import { initializeNodeEnvironment, type InitializeNodeEnvironmentOptions } from '@wixc3/engine-electron-commons';
-import { createMetadataProvider } from '@wixc3/engine-runtime-node';
+import { getMetaData } from '@wixc3/engine-runtime-node';
 import { createDisposables } from '@wixc3/patterns';
 
 /**
@@ -13,9 +13,8 @@ export const initializeNodeEnvironmentInNode: EnvironmentInitializer<
 > = async (options) => {
     const disposables = createDisposables('initializeNodeEnvironmentInNode');
 
-    const metadataProvider = createMetadataProvider(options.communication);
+    const runtimeArguments = await getMetaData(options.communication);
 
-    const runtimeArguments = await metadataProvider.getMetadata();
     const { id, dispose, onExit, environmentIsReady } = initializeNodeEnvironment({
         runtimeArguments,
         ...options,
@@ -25,7 +24,7 @@ export const initializeNodeEnvironmentInNode: EnvironmentInitializer<
     disposables.add({
         name: 'node-environment-dispose',
         timeout: 5_000,
-        dispose: () => Promise.all([metadataProvider.dispose(), dispose()]),
+        dispose,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/packages/runtime-node/src/core-node/create-application-metadata-provider.ts
+++ b/packages/runtime-node/src/core-node/create-application-metadata-provider.ts
@@ -2,7 +2,7 @@ import { Communication } from '@wixc3/engine-core';
 import { metadataApiToken, type MetadataCollectionAPI } from '../types.js';
 import { ENGINE_ROOT_ENVIRONMENT_ID } from './constants.js';
 
-export function createMetadataProvider(com: Communication) {
+export function getMetaData(com: Communication) {
     const api = com.apiProxy<MetadataCollectionAPI>(
         {
             id: ENGINE_ROOT_ENVIRONMENT_ID,
@@ -10,10 +10,5 @@ export function createMetadataProvider(com: Communication) {
         metadataApiToken,
     );
 
-    const metadataPromise = api.getRuntimeArguments();
-
-    return {
-        getMetadata: () => metadataPromise,
-        dispose: () => {},
-    };
+    return api.getRuntimeArguments();
 }

--- a/packages/runtime-node/src/core-node/create-application-metadata-provider.ts
+++ b/packages/runtime-node/src/core-node/create-application-metadata-provider.ts
@@ -1,53 +1,9 @@
 import { Communication } from '@wixc3/engine-core';
-import { createDisposables } from '@wixc3/patterns';
 import { metadataApiToken, type MetadataCollectionAPI } from '../types.js';
-import { ENGINE_ROOT_ENVIRONMENT_ID, METADATA_PROVIDER_ENV_ID } from './constants.js';
+import { ENGINE_ROOT_ENVIRONMENT_ID } from './constants.js';
 
-/**
- * creates a new instance of metadata provider that can get application metadata using `MetadataCollectionAPI` api
- * that should be registered for `ROOT_ENGINE_ENV_ID` environment
- * @param com The communication instance that have registered hosts for `ROOT_ENGINE_ENV_ID` and `METADATA_PROVIDER_ENV_ID`
- */
 export function createMetadataProvider(com: Communication) {
-    const { metadataPromise, disposeCommunication } = loadMetadata(com);
-    return {
-        getMetadata: () => metadataPromise,
-        dispose: disposeCommunication,
-    };
-}
-
-function memoizeOne<A extends object, R>(fn: (arg: A) => R): (arg: A) => R {
-    const argToRes = new WeakMap<A, R>();
-    return (arg: A) => {
-        if (argToRes.has(arg)) {
-            return argToRes.get(arg)!;
-        }
-        const res = fn(arg);
-        argToRes.set(arg, res);
-        return res;
-    };
-}
-
-// memoize function to instantiate single communication instance and call api only once
-const loadMetadata = memoizeOne((communication: Communication) => {
-    const rootHost = communication.getEnvironmentHost(ENGINE_ROOT_ENVIRONMENT_ID);
-    if (!rootHost) {
-        throw new Error(
-            `no host was initialized under the environment ${ENGINE_ROOT_ENVIRONMENT_ID}. Cannot get application metadata API`,
-        );
-    }
-
-    const metadataProviderHost = communication.getEnvironmentHost(METADATA_PROVIDER_ENV_ID);
-    if (!metadataProviderHost) {
-        throw new Error(
-            `no host was initialized under the environment ${METADATA_PROVIDER_ENV_ID}. Cannot get application metadata API`,
-        );
-    }
-
-    const metadataProviderCom = new Communication(metadataProviderHost, METADATA_PROVIDER_ENV_ID);
-    metadataProviderCom.registerEnv(ENGINE_ROOT_ENVIRONMENT_ID, rootHost);
-
-    const api = metadataProviderCom.apiProxy<MetadataCollectionAPI>(
+    const api = com.apiProxy<MetadataCollectionAPI>(
         {
             id: ENGINE_ROOT_ENVIRONMENT_ID,
         },
@@ -56,12 +12,8 @@ const loadMetadata = memoizeOne((communication: Communication) => {
 
     const metadataPromise = api.getRuntimeArguments();
 
-    // use disposables to ignore multiple dispose calls
-    const disposables = createDisposables('metadataProvider');
-    disposables.add('metadataProvider metadataProviderCom', metadataProviderCom);
-
     return {
-        metadataPromise,
-        disposeCommunication: () => disposables.dispose(),
+        getMetadata: () => metadataPromise,
+        dispose: () => {},
     };
-});
+}


### PR DESCRIPTION
This PR simplify the metadata fetching for for `renderer` and `workerthread` initializers 

