### PR TITLE
feat: export runtime engine from main entry point

### DIFF
--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -13,7 +13,7 @@ import type { IRunOptions, TopLevelConfig } from './types.js';
 export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
     public features = new Map<FeatureClass, RuntimeFeature<any, ENV>>();
     public referencedEnvs: Set<string>;
-    private running: Promise<void[]> | undefined;
+    public running: Promise<void[]> | undefined;
     private shutingDown = false;
     private topLevelConfigMap: Record<string, object[]>;
     public runningEnvNames: Set<string>;

--- a/packages/scripts/src/create-node-entrypoint.ts
+++ b/packages/scripts/src/create-node-entrypoint.ts
@@ -79,7 +79,7 @@ if (verbose) {
 
 const unbindMetricsListener = bindMetricsListener();
 
-main({
+export default main({
     featureName: ${stringify(featureName)}, 
     configName: ${stringify(configName)},
     env: ${stringify(runningEnv, null, 2)},
@@ -99,10 +99,11 @@ main({
             ...${stringify(config, null, 2)}
         ];
     },
-}).then(()=>{
+}).then((engine)=>{
     if (verbose) {
         console.log('[${env.name}]: Running')
     }
+    return engine;
 }).catch(e => {
     unbindMetricsListener();
     process.exitCode = 1;


### PR DESCRIPTION
This PR will allow to import the generated environment bundle and run it's engine in the same executaion context. 

This is a starting point to replace the `getRunningFeature` helper