### PR TITLE
feat: added specific disconnect error

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -938,7 +938,7 @@ export class Communication {
                 this.pendingCallbacks.delete(callbackId);
                 delete this.callbacks[callbackId];
                 clearTimeout(timerId);
-                error.stack += `\nCaused by: ${JSON.stringify(cleanMessageForLog(message), null, 2)}`;
+                error.message += `\nCaused by: ${JSON.stringify(cleanMessageForLog(message), null, 2)}`;
                 rej(error);
             };
             if (this.options.warnOnSlow) {

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -55,6 +55,7 @@ import {
     type Target,
     type UnknownFunction,
 } from './types.js';
+import { EnvironmentDisconnectedError } from './environment-disconnected-error.js';
 
 export interface ConfigEnvironmentRecord extends EnvironmentRecord {
     registerMessageHandler?: boolean;
@@ -78,7 +79,7 @@ export class Communication {
     private readonly callbackTimeout = 60_000 * 5; // 5 minutes
     private readonly slowThreshold = 5_000; // 5 seconds
     private callbacks: { [callbackId: string]: CallbackRecord<unknown> } = {};
-    private pendingEnvs: SetMultiMap<string, UnknownFunction> = new SetMultiMap();
+    private pendingEnvs: SetMultiMap<string, () => void> = new SetMultiMap();
     private pendingMessages = new SetMultiMap<string, UnknownFunction>();
     private handlers = new Map<string, Set<UnknownFunction>>();
     private eventDispatchers: { [dispatcherId: string]: SerializableMethod } = {};
@@ -544,15 +545,11 @@ export class Communication {
     }
 
     public envReady(instanceId: string): Promise<void> {
-        const { promise, resolve } = deferred();
         if (this.readyEnvs.has(instanceId)) {
-            // the only way an environment can be in readyEnvs is if handleReady was called (why do we need to call it again?)
-            this.handleReady({ from: instanceId } as ReadyMessage);
-            resolve();
-        } else {
-            this.pendingEnvs.add(instanceId, () => resolve());
+            return Promise.resolve();
         }
-
+        const { promise, resolve } = deferred();
+        this.pendingEnvs.add(instanceId, resolve);
         return promise;
     }
 
@@ -581,7 +578,7 @@ export class Communication {
         for (const [callbackId, env] of this.pendingCallbacks.entries() ?? []) {
             const callbackRecord = this.callbacks[callbackId];
             if (env === instanceId && callbackRecord) {
-                callbackRecord.reject(new Error(ENV_DISCONNECTED(instanceId, this.rootEnvId)));
+                callbackRecord.reject(new EnvironmentDisconnectedError(ENV_DISCONNECTED(instanceId, this.rootEnvId)));
             }
         }
         for (const dispose of this.disposeListeners) {
@@ -941,6 +938,7 @@ export class Communication {
                 this.pendingCallbacks.delete(callbackId);
                 delete this.callbacks[callbackId];
                 clearTimeout(timerId);
+                error.stack += `\nCaused by: ${JSON.stringify(cleanMessageForLog(message), null, 2)}`;
                 rej(error);
             };
             if (this.options.warnOnSlow) {

--- a/packages/core/src/com/environment-disconnected-error.ts
+++ b/packages/core/src/com/environment-disconnected-error.ts
@@ -2,5 +2,6 @@ export class EnvironmentDisconnectedError extends Error {
     constructor(message: string) {
         super(message);
         this.name = 'EnvironmentDisconnectedError';
+        Object.setPrototypeOf(this, new.target.prototype);
     }
 }

--- a/packages/core/src/com/environment-disconnected-error.ts
+++ b/packages/core/src/com/environment-disconnected-error.ts
@@ -1,0 +1,6 @@
+export class EnvironmentDisconnectedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'EnvironmentDisconnectedError';
+    }
+}

--- a/packages/core/src/com/index.ts
+++ b/packages/core/src/com/index.ts
@@ -10,3 +10,4 @@ export * from './types.js';
 export * from './hosts/ws-client-host.js';
 export * from './initializers/index.js';
 export * from './hosts/index.js';
+export * from './environment-disconnected-error.js';

--- a/packages/core/test/communication.spec.ts
+++ b/packages/core/test/communication.spec.ts
@@ -80,10 +80,13 @@ describe('Communication API', function () {
         const env = await iframeInitializer({ communication: com, env: iframeEnv, iframeElement: createIframe() });
 
         const api = com.apiProxy<TestService>(env, { id: testServiceId });
-        const error = await api.failWithError().catch((e: unknown) => e);
+        const error = (await api.failWithError().catch((e) => e)) as typeof testServiceError;
 
         expect(error).to.be.instanceOf(Error);
-        expect(error).to.deep.include(testServiceError);
+
+        expect(error.code).to.deep.equal(testServiceError.code);
+        expect(error.message).to.string(testServiceError.message);
+        expect(error.name).to.string(testServiceError.name);
     });
 
     it('should listen to remote api callbacks', async () => {

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -497,6 +497,15 @@ describe('Communication', () => {
 
         await expect(apiProxy.test()).to.be.rejected;
     });
+
+    it('clearEnvironment', () => {
+        const host = new BaseHost();
+        const com = new Communication(host, 'com');
+        const spyFn = spy();
+        com.subscribeToEnvironmentDispose(spyFn);
+        com.clearEnvironment('env');
+        expect(spyFn).to.have.been.calledWith('env');
+    });
 });
 
 describe('environment-dependencies communication', () => {

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -497,15 +497,6 @@ describe('Communication', () => {
 
         await expect(apiProxy.test()).to.be.rejected;
     });
-
-    it('clearEnvironment', () => {
-        const host = new BaseHost();
-        const com = new Communication(host, 'com');
-        const spyFn = spy();
-        com.subscribeToEnvironmentDispose(spyFn);
-        com.clearEnvironment('env');
-        expect(spyFn).to.have.been.calledWith('env');
-    });
 });
 
 describe('environment-dependencies communication', () => {

--- a/packages/runtime-node/test/node-com.unit.ts
+++ b/packages/runtime-node/test/node-com.unit.ts
@@ -328,7 +328,7 @@ describe('IPC communication', () => {
         const { waitForCall, spy } = createWaitForCall<(e: Error) => void>();
         proxy.echo().catch(spy);
         await waitForCall((args) => {
-            expect(args[0].message).to.eq('Remote call failed in "process" - environment disconnected at "main"');
+            expect(args[0].message).to.have.string('Remote call failed in "process" - environment disconnected at "main"');
         });
     });
 });


### PR DESCRIPTION
Since most places want to ignore a disconnect error now they can do it easily

* Removed unnecessary `handleReady` call when calling `envReady` add an environment to pending state
* Better error when rejecting a callback (include origin message)