### PR TITLE
refactor: remove unused configName

### DIFF
--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -320,7 +320,6 @@ export function runNodeManager({
         {
             cwd: cwd ? resolve(cwd) : process.cwd(),
             execArgv: watch ? process.execArgv.concat(['--watch']) : process.execArgv,
-            // execArgv: process.execArgv,
         },
     );
     return { managerProcess };

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -356,7 +356,6 @@ async function launchDevServer(
 export async function runLocalNodeManager(
     featureEnvironmentsMapping: FeatureEnvironmentMapping,
     configMapping: ConfigurationEnvironmentMapping,
-    configName: string,
     execRuntimeOptions: Map<string, string | boolean | undefined>,
     outputPath: string = 'dist-engine',
 ) {

--- a/packages/scripts/src/utils/environments.ts
+++ b/packages/scripts/src/utils/environments.ts
@@ -17,7 +17,7 @@ export interface IResolvedEnvironment {
 }
 
 export function* getExportedEnvironments(
-    features: Map<string, { exportedEnvs: IEnvironmentDescriptor<AnyEnvironment>[] }>
+    features: Map<string, { exportedEnvs: IEnvironmentDescriptor<AnyEnvironment>[] }>,
 ) {
     for (const { exportedEnvs } of features.values()) {
         for (const exportedEnv of exportedEnvs) {
@@ -43,8 +43,9 @@ export function getResolvedEnvironments({
     const resolvedContexts = findAllEnvironments
         ? getPossibleContexts(features)
         : featureName && filterContexts
-        ? convertEnvRecordToSetMultiMap(features.get(featureName)?.resolvedContexts ?? {})
-        : getAllResolvedContexts(features);
+          ? convertEnvRecordToSetMultiMap(features.get(featureName)?.resolvedContexts ?? {})
+          : getAllResolvedContexts(features);
+
     for (const env of environments) {
         const { name, childEnvName, type } = env;
         if (!resolvedContexts.hasKey(name) || (childEnvName && resolvedContexts.get(name)?.has(childEnvName))) {
@@ -69,6 +70,7 @@ export function getResolvedEnvironments({
         webEnvs,
         workerEnvs,
         electronRendererEnvs,
+        electronMainEnvs,
         nodeEnvs,
         workerThreadEnvs,
     };

--- a/packages/test-kit/src/engine-app-manager.ts
+++ b/packages/test-kit/src/engine-app-manager.ts
@@ -32,7 +32,7 @@ export class ManagedRunEngine implements IExecutableApplication {
             return;
         }
         const engineConfig = await loadEngineConfig(process.cwd());
-        
+
         const buildOnlyInDevModeOptions: RunEngineOptions = {
             build: true,
             clean: true,
@@ -77,7 +77,6 @@ export class ManagedRunEngine implements IExecutableApplication {
         const { port, manager } = await runLocalNodeManager(
             this.runMetadata.featureEnvironmentsMapping,
             this.runMetadata.configMapping,
-            configName,
             execRuntimeOptions,
             OUTPUT_PATH,
         );


### PR DESCRIPTION
 Also add `electronMainEnvs` to the return of `getExportedEnvironments` to be used to create configurations for build