### PR TITLE
feat: fix commander issues with new version

### DIFF
--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -63,7 +63,6 @@ const engineCommandBuilder = (program: Command, command: string): Command => {
 export const startCommand: CliCommand = (program) =>
     engineCommandBuilder(program, 'start [path]')
         .option('--mode <production|development>', 'mode passed to webpack', 'development')
-        .option('--inspect')
         .option('-p ,--port <port>')
         .option('--open <open>')
         .option(

--- a/packages/runtime-node/src/remote-node-environment.ts
+++ b/packages/runtime-node/src/remote-node-environment.ts
@@ -16,7 +16,7 @@ export async function startRemoteNodeEnvironment(
     entryFilePath: string,
     { inspect, port, socketServerOptions = {}, requiredPaths = [] }: IStartRemoteNodeEnvironmentOptions,
 ) {
-    const execArgv = inspect ? ['--inspect'] : [];
+    const execArgv = inspect && !process.execArgv.includes('--inspect') ? ['--inspect'] : [];
 
     const childProccess = fork(
         entryFilePath,


### PR DESCRIPTION
Reused base `engineCommandBuilder` duplicate `--inspect` options cause `commander` new version to throw