### PR TITLE
fix: continue run after initial build failed.

### DIFF
--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -132,7 +132,7 @@ export async function runEngine({
             if (verbose) {
                 console.log('Waiting for web build end.');
             }
-            await waitForBuildEnd();
+            await Promise.allSettled([waitForBuildEnd()]);
         }
 
         if (buildTargets === 'node' || buildTargets === 'both') {
@@ -146,7 +146,7 @@ export async function runEngine({
             if (verbose) {
                 console.log('Waiting for node build end.');
             }
-            await waitForBuildEnd();
+            await Promise.allSettled([waitForBuildEnd()]);
         }
     } else if (build) {
         const start = performance.now();


### PR DESCRIPTION
in watch mode if we start with a broken build. we still run the dashboard 