### PR TITLE
fix: slow debug

### DIFF
--- a/packages/engine-cli/src/create-environments-build-configuration.ts
+++ b/packages/engine-cli/src/create-environments-build-configuration.ts
@@ -40,7 +40,7 @@ export function createBuildConfiguration(options: CreateBuildConfigOptions) {
     const commonConfig = {
         target: 'es2020',
         bundle: true,
-        format: 'esm',
+        format: 'iife',
         publicPath,
         metafile: true,
         sourcemap: true,

--- a/packages/engine-cli/src/create-environments-build-configuration.ts
+++ b/packages/engine-cli/src/create-environments-build-configuration.ts
@@ -49,7 +49,6 @@ export function createBuildConfiguration(options: CreateBuildConfigOptions) {
         metafile: true,
         sourcemap: true,
         keepNames: true,
-        treeShaking: true,
         conditions: buildConditions,
         resolveExtensions: extensions,
         outExtension: { '.js': jsOutExtension },

--- a/packages/engine-cli/src/create-environments-build-configuration.ts
+++ b/packages/engine-cli/src/create-environments-build-configuration.ts
@@ -40,11 +40,16 @@ export function createBuildConfiguration(options: CreateBuildConfigOptions) {
     const commonConfig = {
         target: 'es2020',
         bundle: true,
+        /*
+            using iife here because esm makes debugging very slow to pickup variables in scope.
+            if one want to change this to esm, make sure that some bundle splitting is happening.
+        */
         format: 'iife',
         publicPath,
         metafile: true,
         sourcemap: true,
         keepNames: true,
+        treeShaking: true,
         conditions: buildConditions,
         resolveExtensions: extensions,
         outExtension: { '.js': jsOutExtension },


### PR DESCRIPTION
So when using esm bundle the devtools work very hard in order to show the `Module` keys in the scopes panel. using iife fixes that and we don't acctualy use the esbuild entry bundle as importable files (library)  