### PR TITLE
fix: forward respect pendingEnvs

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -608,7 +608,10 @@ export class Communication {
         } else if (this.DEBUG) {
             console.debug(FORWARDING_MESSAGE(cleanMessageForLog(message), this.rootEnvId, env.id));
         }
-
+        if (this.pendingEnvs.get(env.id)) {
+            this.pendingMessages.add(env.id, () => this.post(this.resolveMessageTarget(env.id), message));
+            return;
+        }
         this.post(env.host, message);
     }
 

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -35,7 +35,6 @@ import type {
     EventMessage,
     ListenMessage,
     Message,
-    ReadyMessage,
     StatusMessage,
     UnListenMessage,
 } from './message-types.js';
@@ -768,7 +767,7 @@ export class Communication {
         }
     }
 
-    public handleReady({ from }: ReadyMessage): void {
+    public handleReady({ from }: { from: string }): void {
         this.readyEnvs.add(from);
         const pendingEnvCb = this.pendingEnvs.get(from);
         if (pendingEnvCb) {

--- a/packages/core/src/com/initializers/socket-server.ts
+++ b/packages/core/src/com/initializers/socket-server.ts
@@ -1,6 +1,5 @@
 import type { SocketOptions } from 'socket.io-client';
 import { WsClientHost } from '../hosts/ws-client-host.js';
-import type { ReadyMessage } from '../message-types.js';
 import type { InitializerOptions } from './types.js';
 
 export interface SocketClientInitializerOptions extends InitializerOptions, Partial<SocketOptions> {}
@@ -26,7 +25,7 @@ export const socketClientInitializer = async ({
         throw e;
     }
 
-    communication.handleReady({ from: instanceId } as ReadyMessage);
+    communication.handleReady({ from: instanceId });
 
     return {
         id: instanceId,

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -12,12 +12,11 @@ import {
     Slot,
     multiTenantMethod,
     type Message,
-    type ReadyMessage,
 } from '@wixc3/engine-core';
 import { EventEmitter } from '@wixc3/patterns';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { waitFor } from 'promise-assist';
+import { sleep, waitFor } from 'promise-assist';
 import { spy, stub } from 'sinon';
 import sinonChai from 'sinon-chai';
 
@@ -159,6 +158,46 @@ describe('Communication', () => {
         expect(handleMessageStub).to.have.not.been.called;
     });
 
+    it('forwards to pending envs wait until resolve', async () => {
+        const middlemanHost = new BaseHost();
+        const aHost = new BaseHost();
+        const bHost = new BaseHost();
+
+        const mainCom = new Communication(middlemanHost, 'middle');
+        const bCom = new Communication(bHost, 'bEnv');
+        const aCom = new Communication(aHost, 'aEnv');
+
+        disposables.add(mainCom);
+        disposables.add(bCom);
+        disposables.add(aCom);
+
+        aCom.registerEnv('middle', middlemanHost);
+        aCom.registerEnv('bEnv', middlemanHost); // bEnv is registered with middlemanHost
+
+        mainCom.registerEnv('aEnv', aHost);
+        mainCom.registerEnv('bEnv', bHost);
+
+        // bEnv is not ready to receive messages yet
+        void mainCom.envReady('bEnv');
+
+        bCom.registerEnv('aEnv', middlemanHost); // aEnv is registered with middlemanHost
+
+        const api = {
+            spy: spy(),
+        };
+        bCom.registerAPI({ id: 'myApi' }, api);
+
+        const mockApiProxyFromAEnv = aCom.apiProxy<typeof api>({ id: 'bEnv' }, { id: 'myApi' });
+        const done = mockApiProxyFromAEnv.spy();
+        // calling the remote api takes several micro ticks, so we wait one tick.
+        await sleep(0);
+        expect(api.spy).to.have.callCount(0);
+        mainCom.handleReady({ from: 'bEnv' });
+        await sleep(0);
+        expect(api.spy).to.have.callCount(1);
+        await done;
+    });
+
     it('forwards listen calls', async () => {
         const middlemanHost = new BaseHost();
         const aHost = new BaseHost();
@@ -256,8 +295,8 @@ describe('Communication', () => {
         bCom.registerEnv('aEnv', middlemanHost);
         mainCom.registerEnv('aEnv', aHost);
         mainCom.registerEnv('bEnv', bHost);
-        aCom.handleReady({ from: 'bEnv' } as ReadyMessage);
-        bCom.handleReady({ from: 'anv' } as ReadyMessage);
+        aCom.handleReady({ from: 'bEnv' });
+        bCom.handleReady({ from: 'anv' });
 
         const echoService = {
             echo() {

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -171,7 +171,6 @@ describe('Communication', () => {
         disposables.add(bCom);
         disposables.add(aCom);
 
-        aCom.registerEnv('middle', middlemanHost);
         aCom.registerEnv('bEnv', middlemanHost); // bEnv is registered with middlemanHost
 
         mainCom.registerEnv('aEnv', aHost);

--- a/packages/runtime-node/src/node-environments-manager.ts
+++ b/packages/runtime-node/src/node-environments-manager.ts
@@ -5,7 +5,6 @@ import {
     Communication,
     type ConfigEnvironmentRecord,
     type Message,
-    type ReadyMessage,
     type TopLevelConfig,
 } from '@wixc3/engine-core';
 import type { SetMultiMap } from '@wixc3/patterns';
@@ -297,8 +296,8 @@ export class NodeEnvironmentsManager {
         const overrideConfig = Array.isArray(overrideConfigProvider)
             ? overrideConfigProvider
             : envName
-            ? overrideConfigProvider(envName)
-            : [];
+              ? overrideConfigProvider(envName)
+              : [];
         const overrideConfigs = [...overrideConfig];
         if (configName) {
             const currentOverrideConfig = overrideConfigsMap.get(configName);
@@ -406,7 +405,7 @@ export class NodeEnvironmentsManager {
             com.clearEnvironment(nodeEnv.name);
             com.registerMessageHandler(ipcHost);
             com.registerEnv(nodeEnv.name, ipcHost);
-            com.handleReady({ from: nodeEnv.name } as ReadyMessage);
+            com.handleReady({ from: nodeEnv.name });
             return {
                 port,
                 start,


### PR DESCRIPTION
In the case of forward message between source env (processing), forwarder env (manager) and target env (main).
if the manager has the main environment as pending it will now wait until the target will be resolved to send any messages.

* loosen the type for `handleReady` to allow manual management  

TODO: 
- [x] test 