### PR TITLE
feat: enable static build

### DIFF
--- a/packages/engine-cli/src/cli.ts
+++ b/packages/engine-cli/src/cli.ts
@@ -99,6 +99,11 @@ async function engine() {
             description: 'Public path',
             default: '',
         },
+        staticBuild: {
+            type: Boolean,
+            description: 'Enable config build via config loaders',
+            default: false,
+        },
         configLoadingMode: {
             type: (value: string) => {
                 if (value === 'fresh' || value === 'watch' || value === 'require') {

--- a/packages/engine-cli/src/create-entrypoints.ts
+++ b/packages/engine-cli/src/create-entrypoints.ts
@@ -26,6 +26,7 @@ export interface CreateEntryPointOptions {
     featureName?: string;
     configName?: string;
     buildElectron?: boolean;
+    staticBuild: boolean;
 }
 
 export type EntryPoints = {
@@ -56,6 +57,7 @@ export function createEntryPoints(
         configMapping,
         publicConfigsRoute,
         buildElectron,
+        staticBuild,
     } = options;
 
     const mode = dev ? 'development' : 'production';
@@ -92,7 +94,7 @@ export function createEntryPoints(
             publicPathVariableName: 'PUBLIC_PATH',
             configurations,
             mode,
-            staticBuild: false,
+            staticBuild,
             publicConfigsRoute,
             config,
         });

--- a/packages/engine-cli/src/create-environments-build-configuration.ts
+++ b/packages/engine-cli/src/create-environments-build-configuration.ts
@@ -17,6 +17,7 @@ export interface CreateBuildConfigOptions {
     jsOutExtension: '.js' | '.mjs';
     nodeFormat: 'esm' | 'cjs';
     entryPointsPaths?: EntryPointsPaths;
+    staticBuild: boolean;
 }
 
 export function createBuildConfiguration(options: CreateBuildConfigOptions) {
@@ -31,6 +32,7 @@ export function createBuildConfiguration(options: CreateBuildConfigOptions) {
         jsOutExtension,
         nodeFormat,
         entryPointsPaths,
+        staticBuild,
     } = options;
     const { webEntryPoints, nodeEntryPoints } = entryPoints;
     const { webEntryPointsPaths, nodeEntryPointsPaths } = entryPointsPaths || {};
@@ -62,7 +64,7 @@ export function createBuildConfiguration(options: CreateBuildConfigOptions) {
             '.woff2': 'file',
             '.ttf': 'file',
         },
-        plugins: [...commonPlugins, topLevelConfigPlugin({ emit: !dev })],
+        plugins: [...commonPlugins, topLevelConfigPlugin({ emit: staticBuild || !dev })],
     } satisfies BuildOptions;
 
     const webConfig = {

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -39,6 +39,7 @@ export interface RunEngineOptions {
     publicPath?: string;
     publicConfigsRoute?: string;
     configLoadingMode?: ConfigLoadingMode;
+    staticBuild?: boolean;
 }
 
 export async function runEngine({
@@ -61,6 +62,7 @@ export async function runEngine({
     writeMetadataFiles = !watch,
     publicConfigsRoute = 'configs',
     configLoadingMode = 'require',
+    staticBuild = false,
 }: RunEngineOptions = {}): Promise<{
     featureEnvironmentsMapping: FeatureEnvironmentMapping;
     configMapping: ConfigurationEnvironmentMapping;
@@ -124,6 +126,7 @@ export async function runEngine({
             publicConfigsRoute,
             jsOutExtension,
             nodeFormat,
+            staticBuild,
             buildElectron: buildTargets === 'electron',
         });
 
@@ -167,6 +170,7 @@ export async function runEngine({
         jsOutExtension,
         nodeFormat,
         entryPointsPaths,
+        staticBuild
     });
 
     if (watch) {

--- a/packages/engine-cli/src/resolve-build-configurations.ts
+++ b/packages/engine-cli/src/resolve-build-configurations.ts
@@ -18,6 +18,7 @@ export function resolveBuildEntryPoints({
     publicConfigsRoute,
     jsOutExtension,
     nodeFormat,
+    staticBuild,
     buildElectron,
 }: {
     features: Map<string, IFeatureDefinition>;
@@ -30,6 +31,7 @@ export function resolveBuildEntryPoints({
     publicConfigsRoute: string;
     jsOutExtension: '.js' | '.mjs';
     nodeFormat: 'esm' | 'cjs';
+    staticBuild: boolean;
     buildElectron?: boolean;
 }) {
     const featureEnvironmentsMapping = createFeatureEnvironmentsMapping(features);
@@ -56,6 +58,7 @@ export function resolveBuildEntryPoints({
             configName,
             featureName,
             buildElectron,
+            staticBuild,
         },
         jsOutExtension,
         nodeFormat,

--- a/packages/engine-cli/src/top-level-config-plugin-esbuild.ts
+++ b/packages/engine-cli/src/top-level-config-plugin-esbuild.ts
@@ -1,6 +1,6 @@
 import { BuildOptions, Plugin } from 'esbuild';
 import fs from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 
 export interface PartialWebpackLoaderContext {
     query: string;
@@ -86,5 +86,6 @@ function emitConfigFile(
     const content = JSON.stringify(imported.default ?? imported);
     const configFileName = envName ? `${fileName!}.${envName}` : fileName;
     const configPath = `configs/${configFileName!}.json`;
-    filesToEmit.set(configPath, { content, path: join(rootContext, outDir, configPath) });
+    const path = isAbsolute(outDir) ? join(outDir, configPath) : join(rootContext, outDir, configPath);
+    filesToEmit.set(configPath, { content, path });
 }

--- a/packages/engine-cli/src/top-level-config-plugin-esbuild.ts
+++ b/packages/engine-cli/src/top-level-config-plugin-esbuild.ts
@@ -1,6 +1,6 @@
 import { BuildOptions, Plugin } from 'esbuild';
 import fs from 'node:fs';
-import { dirname, isAbsolute, join } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 export interface PartialWebpackLoaderContext {
     query: string;
@@ -86,6 +86,5 @@ function emitConfigFile(
     const content = JSON.stringify(imported.default ?? imported);
     const configFileName = envName ? `${fileName!}.${envName}` : fileName;
     const configPath = `configs/${configFileName!}.json`;
-    const path = isAbsolute(outDir) ? join(outDir, configPath) : join(rootContext, outDir, configPath);
-    filesToEmit.set(configPath, { content, path });
+    filesToEmit.set(configPath, { content, path: resolve(rootContext, outDir, configPath) });
 }


### PR DESCRIPTION
This PR address missing `staticBuild` option in the new esbuild flow.

When building targets that requires fully static build like electron we need to build the config files to disk. 
This PR enables this feature in the esbuild flow.

This PR also fixes a build in the config loader when the `outDir` is absolute.
 