### PR TITLE
feat(core): allow passing entry options via script query

### DIFF
--- a/packages/core/src/helpers/web.ts
+++ b/packages/core/src/helpers/web.ts
@@ -9,3 +9,22 @@ export function injectScript(win: Window, rootComId: string, scriptUrl: string) 
         win.document.head.appendChild(scriptEl);
     });
 }
+
+export function getEngineEntryOptions(envName: string) {
+    const urlParams = new URLSearchParams(globalThis.location.search);
+    const currentScript = globalThis.document?.currentScript
+    const isHtmlScript = !!currentScript && 'src' in currentScript;
+
+    const scriptQueryString = isHtmlScript && currentScript.src?.split?.('?')?.[1] || ''
+    const scriptUrlParams = new URLSearchParams(scriptQueryString)
+    const injectedOptions = globalThis.engineEntryOptions?.({ urlParams, envName }) ?? new URLSearchParams('');
+
+    const definedParams = new Set<string>()
+    return new URLSearchParams([...injectedOptions, ...urlParams, ...scriptUrlParams].filter(([key]) => {
+        if (definedParams.has(key)) {
+            return false
+        }
+        definedParams.add(key)
+        return true
+    }))
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -171,6 +171,8 @@ export interface IRunOptions {
     has(key: string): boolean;
     get(key: string): string | string[] | boolean | null | undefined;
     entries(): IterableIterator<[string, string | string[] | boolean | null | undefined]>;
+
+    [Symbol.iterator](): IterableIterator<[string, string | string[] | boolean | null | undefined]>;
 }
 
 export type RegisteringFeature<

--- a/packages/core/test/helpers.spec.ts
+++ b/packages/core/test/helpers.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { getEngineEntryOptions } from '@wixc3/engine-core';
+
+describe('helpers', () => {
+  describe('getEngineEntryOptions', () => {
+    it('it gets engine entry options from query string, from script url, from engineEntryOptions', () => {
+      const document = { currentScript: { dataset: { engineRunOptions: 'http://localhost:3000?one=0&two=1&script=123' } } } as unknown as Document;
+      const location = { search: 'one=2&two=2&search=123' } as Location;
+      const engineEntryOptions = ({ envName }: { envName: string }) => {
+        if (envName === 'thisTest') {
+          return new URLSearchParams([['injected', '123'], ['one', '1']]);
+        }
+        return new URLSearchParams();
+      };
+      const result = getEngineEntryOptions('thisTest', { document, location, engineEntryOptions });
+
+      expect(result.get('one'), 'Priorities injected options over search string and script url').to.eql('1');
+      expect(result.get('two'), 'Priorities search params over script url').to.eql('2');
+      expect(result.get('script'), 'Gets options from script url').to.eql('123');
+      expect(result.get('search'), 'Gets options from search string').to.eql('123');
+      expect(result.get('injected'), 'Gets options from engineEntryOptions').to.eql('123');
+    });
+  });
+});
+

--- a/packages/core/test/helpers.spec.ts
+++ b/packages/core/test/helpers.spec.ts
@@ -1,25 +1,60 @@
 import { expect } from 'chai';
-import { getEngineEntryOptions } from '@wixc3/engine-core';
+import { getEngineEntryOptions, IRunOptions } from '@wixc3/engine-core';
 
 describe('helpers', () => {
-  describe('getEngineEntryOptions', () => {
-    it('it gets engine entry options from query string, from script url, from engineEntryOptions', () => {
-      const document = { currentScript: { dataset: { engineRunOptions: 'http://localhost:3000?one=0&two=1&script=123' } } } as unknown as Document;
-      const location = { search: 'one=2&two=2&search=123' } as Location;
-      const engineEntryOptions = ({ envName }: { envName: string }) => {
-        if (envName === 'thisTest') {
-          return new URLSearchParams([['injected', '123'], ['one', '1']]);
-        }
-        return new URLSearchParams();
-      };
-      const result = getEngineEntryOptions('thisTest', { document, location, engineEntryOptions });
+    describe('getEngineEntryOptions', () => {
+        it('it gets engine entry options from query string, from script url, from engineEntryOptions', () => {
+            const document = {
+                currentScript: { dataset: { engineRunOptions: 'http://localhost:3000?one=0&two=1&script=123' } },
+            };
+            const location = { search: 'one=2&two=2&search=123' };
+            const engineEntryOptions = ({
+                envName,
+                currentRunOptions,
+            }: {
+                envName: string;
+                currentRunOptions: IRunOptions;
+            }) => {
+                if (envName === 'thisTest') {
+                    return new Map([...currentRunOptions, ['injected', '123'], ['one', '1']]);
+                }
+                return new Map();
+            };
+            const result = getEngineEntryOptions('thisTest', { document, location, engineEntryOptions });
 
-      expect(result.get('one'), 'Priorities injected options over search string and script url').to.eql('1');
-      expect(result.get('two'), 'Priorities search params over script url').to.eql('2');
-      expect(result.get('script'), 'Gets options from script url').to.eql('123');
-      expect(result.get('search'), 'Gets options from search string').to.eql('123');
-      expect(result.get('injected'), 'Gets options from engineEntryOptions').to.eql('123');
+            expect(result.get('one'), 'Prioritises injected options over search string and script url').to.eql('1');
+            expect(result.get('two'), 'Prioritises search params over script url').to.eql('2');
+            expect(result.get('script'), 'Gets options from script url').to.eql('123');
+            expect(result.get('search'), 'Gets options from search string').to.eql('123');
+            expect(result.get('injected'), 'Gets options from engineEntryOptions').to.eql('123');
+        });
+        it('works without inject function', () => {
+            const document = {
+                currentScript: { dataset: { engineRunOptions: 'http://localhost:3000?one=0&script=123' } },
+            };
+            const location = { search: 'one=1&search=123' };
+            const result = getEngineEntryOptions('thisTest', { document, location });
+
+            expect(result.get('one'), 'Prioritises injected options over search string and script url').to.eql('1');
+            expect(result.get('script'), 'Gets options from script url').to.eql('123');
+            expect(result.get('search'), 'Gets options from search string').to.eql('123');
+        });
+        it('allows to override options completely with getEngineEntryOptions', () => {
+            const document = {
+                currentScript: { dataset: { engineRunOptions: 'http://localhost:3000?script=123' } },
+            };
+            const location = { search: 'search=123' };
+            const engineEntryOptions = ({ envName }: { envName: string }) => {
+                if (envName === 'thisTest') {
+                    return new Map([['injected', '123']]);
+                }
+                return new Map();
+            };
+            const result = getEngineEntryOptions('thisTest', { document, location, engineEntryOptions });
+
+            expect(result.get('script'), 'Ignores options from script url').to.eql(undefined);
+            expect(result.get('search'), 'Ignores options from search string').to.eql(undefined);
+            expect(result.get('injected'), 'Gets options from engineEntryOptions').to.eql('123');
+        });
     });
-  });
 });
-

--- a/packages/scripts/src/create-web-entrypoint.ts
+++ b/packages/scripts/src/create-web-entrypoint.ts
@@ -48,7 +48,7 @@ export function createMainEntrypoint({
     return `
 import { main, COM, getEngineEntryOptions } from '@wixc3/engine-core';
 
-const options = getEngineEntryOptions(${stringify(env.name)})
+const options = getEngineEntryOptions(${stringify(env.name)}, globalThis)
 const runtimePublicPath = ${runtimePublicPath};
 main({
     featureName: ${stringify(featureName)}, 

--- a/packages/scripts/src/create-web-entrypoint.ts
+++ b/packages/scripts/src/create-web-entrypoint.ts
@@ -46,10 +46,9 @@ export function createMainEntrypoint({
     );
 
     return `
-import { main, COM } from '@wixc3/engine-core';
+import { main, COM, getEngineEntryOptions } from '@wixc3/engine-core';
 
-const urlParams = new URLSearchParams(globalThis.location.search);
-const options = globalThis.engineEntryOptions?.({ urlParams, envName: ${stringify(env.name)} }) ?? urlParams;
+const options = getEngineEntryOptions(${stringify(env.name)})
 const runtimePublicPath = ${runtimePublicPath};
 main({
     featureName: ${stringify(featureName)}, 


### PR DESCRIPTION
For the abomination. Providing entry options by other means than the search params will allow to keep the iframe url clean which is vital when running the full app instead of a board.