### PR TITLE
feat(dashboard): distinguish parent and child relations on a graph

### DIFF
--- a/packages/dashboard/src/components/feature-graph.tsx
+++ b/packages/dashboard/src/components/feature-graph.tsx
@@ -85,8 +85,8 @@ export const FeatureGraph = memo(({ selectedFeatureGraph }: IFeatureGraphProps) 
                         return linkedNodes[0] === graphNode
                             ? linkedNodes[linkedNodes.length - 1]
                             : linkedNodes[linkedNodes.length - 1] === graphNode
-                            ? linkedNodes[0]
-                            : 0;
+                              ? linkedNodes[0]
+                              : 0;
                     })
                     .filter(function (d) {
                         return d;
@@ -99,9 +99,11 @@ export const FeatureGraph = memo(({ selectedFeatureGraph }: IFeatureGraphProps) 
                 link.style('stroke-opacity', function (linkedNodes) {
                     return linkedNodes[0] === graphNode || linkedNodes[linkedNodes.length - 1] === graphNode ? 1 : null;
                 }).style('stroke', function (linkedNodes) {
-                    return linkedNodes[0] === graphNode || linkedNodes[linkedNodes.length - 1] === graphNode
-                        ? '#d62333'
-                        : null;
+                    // when current feature is using the linked feature
+                    if (linkedNodes[0] === graphNode) return '#d62333';
+                    // when linked feature is using the current feature
+                    if (linkedNodes[linkedNodes.length - 1] === graphNode) return '#9932a8';
+                    return null;
                 });
             })
             .on('mouseout', function () {


### PR DESCRIPTION
I had a task to refactor some fixtures in the Codux. I decided to use our feature graph for that and it was really useful.
However when viewing feature graph I noticed that all links - parent and child are highlighted in the same color. I could not understand looking at a graph where was my feature requested as a child. Take a look at this:

![image](https://github.com/wixplosives/engine/assets/86300936/0d58a627-d774-4fe5-8681-3ffe71c79d1f)

I hovered over file-assets and it is impossible to tell which related feature uses file-assets vs which is used by file-assets.

So I propose to use different colors for parent links vs child links. I used this approach personally in my abovementioned task and it helped me a lot! So I decided to create this PR, maybe it will help other people when playing with features

After applying my changes:
![image](https://github.com/wixplosives/engine/assets/86300936/af569d90-3c5b-4e2f-ae4f-54c2e7225d85)

You can clearly see different colored lines and distinguish parent vs child relations.
If you don't like the suggested color, please feel free to fix it.

