### PR TITLE
infra!: remove webpack from scripts index

### DIFF
--- a/packages/engine-cli/src/cli.ts
+++ b/packages/engine-cli/src/cli.ts
@@ -1,6 +1,6 @@
 import { cli, command } from 'cleye';
 import { analyzeCommand } from './analyze-command';
-import { EngineConfig } from '@wixc3/engine-scripts';
+import type { EngineConfig } from '@wixc3/engine-scripts';
 
 async function engine() {
     const engineConfigCli = cli({

--- a/packages/engineer/src/application-proxy-service.ts
+++ b/packages/engineer/src/application-proxy-service.ts
@@ -2,15 +2,17 @@ import { nodeFs } from '@file-services/node';
 import type { IConfigDefinition, LaunchEnvironmentMode, NodeEnvironmentsManager } from '@wixc3/engine-runtime-node';
 import {
     analyzeFeatures,
-    Application,
     generateConfigName,
-    type IApplicationOptions,
-    type ICompilerOptions,
     type IFeatureDefinition,
     type IFeatureMessagePayload,
-    type IRunFeatureOptions,
     type OverrideConfig,
 } from '@wixc3/engine-scripts';
+import {
+    Application,
+    type IApplicationOptions,
+    type ICompilerOptions,
+    type IRunFeatureOptions,
+} from '@wixc3/engine-scripts/dist/application/index.js';
 import type { SetMultiMap } from '@wixc3/patterns';
 
 export class TargetApplication extends Application {

--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -8,7 +8,7 @@
 import { nodeFs as fs } from '@file-services/node';
 import { createRequestResolver } from '@file-services/resolve';
 import { parseCliArguments } from '@wixc3/engine-runtime-node';
-import { Application } from '@wixc3/engine-scripts';
+import { Application } from '@wixc3/engine-scripts/dist/application';
 import type { Command } from 'commander';
 import { resolve } from 'node:path';
 import open from 'open';

--- a/packages/engineer/src/cli-commands.ts
+++ b/packages/engineer/src/cli-commands.ts
@@ -8,7 +8,7 @@
 import { nodeFs as fs } from '@file-services/node';
 import { createRequestResolver } from '@file-services/resolve';
 import { parseCliArguments } from '@wixc3/engine-runtime-node';
-import { Application } from '@wixc3/engine-scripts/dist/application';
+import { Application } from '@wixc3/engine-scripts/dist/application/index.js';
 import type { Command } from 'commander';
 import { resolve } from 'node:path';
 import open from 'open';

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./dist/application/index.js": "./dist/application/index.js",
     "./dist/default-config-loader": "./dist/default-config-loader.js",
     "./dist/analyze-feature/merge": "./dist/analyze-feature/merge.js",
     "./package.json": "./package.json"

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -11,5 +11,5 @@ export * from './resolve-exec-argv.js';
 export * from './run-environment.js';
 export * from './types.js';
 export * from './utils/index.js';
-export { createVirtualEntries, type VirtualModulesLoaderOptions } from './virtual-modules-loader';
+export { createVirtualEntries, type VirtualModulesLoaderOptions } from './virtual-modules-loader.js';
 export { importFresh } from './import-fresh.js';

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -1,5 +1,4 @@
 export * from './analyze-feature/index.js';
-export * from './application/index.js';
 export * from './build-constants.js';
 export * from './config-middleware.js';
 export * from './create-entrypoint.js';
@@ -13,5 +12,4 @@ export * from './run-environment.js';
 export * from './types.js';
 export * from './utils/index.js';
 export { createVirtualEntries, type VirtualModulesLoaderOptions } from './virtual-modules-loader';
-export * from './webpack-html-attributes-plugins.js';
 export { importFresh } from './import-fresh.js';

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -1,7 +1,7 @@
 import { nodeFs as fs } from '@file-services/node';
 import { createDisposables } from '@wixc3/create-disposables';
 import type { EngineerMetadataConfig, TopLevelConfig } from '@wixc3/engine-core';
-import { Application, type IBuildManifest } from '@wixc3/engine-scripts';
+import { Application, type IBuildManifest } from '@wixc3/engine-scripts/dist/application/index';
 import { createBrowserProvider } from '@wixc3/engine-test-kit';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -24,7 +24,7 @@ describe('Application', function () {
         this.timeout(30_000);
         return disposables.dispose();
     });
-    after(()=>browserProvider.dispose());
+    after(() => browserProvider.dispose());
 
     const loadPage = async (url: string) => {
         const page = await browserProvider.loadPage(url);

--- a/packages/scripts/test/application.unit.ts
+++ b/packages/scripts/test/application.unit.ts
@@ -1,7 +1,7 @@
 import { nodeFs as fs } from '@file-services/node';
 import { createDisposables } from '@wixc3/create-disposables';
 import type { EngineerMetadataConfig, TopLevelConfig } from '@wixc3/engine-core';
-import { Application, type IBuildManifest } from '@wixc3/engine-scripts/dist/application/index';
+import { Application, type IBuildManifest } from '@wixc3/engine-scripts/dist/application/index.js';
 import { createBrowserProvider } from '@wixc3/engine-test-kit';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';


### PR DESCRIPTION
This PR removes all non type exports from webpack done via engine-scripts.
The bigger job is to remove all webpack related code that is soon going to be dead code.
