### PR TITLE
Kate/fix env dispose gets stuck

### DIFF
--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -102,11 +102,21 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
             this.running = undefined;
             const toDispose = Array.from(this.features.values()).reverse();
             for (const feature of toDispose) {
+                const startTime = Date.now();
+                const intervalId = setInterval(() => {
+                    console.log(
+                        `[${this.entryEnvironment.env}]: Feature ${feature.feature.id} "dispose()" is taking ${(
+                            (Date.now() - startTime) /
+                            1000
+                        ).toFixed(2)}s`,
+                    );
+                }, 50);
                 await timeout(
                     feature.dispose(),
                     this.featureShutdownTimeout,
                     `Failed to dispose feature: ${feature.feature.id}`,
                 );
+                clearInterval(intervalId);
             }
         } finally {
             this.shutingDown = false;

--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -111,12 +111,15 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
                         ).toFixed(2)}s`,
                     );
                 }, 50);
-                await timeout(
-                    feature.dispose(),
-                    this.featureShutdownTimeout,
-                    `Failed to dispose feature: ${feature.feature.id}`,
-                );
-                clearInterval(intervalId);
+                try {
+                    await timeout(
+                        feature.dispose(),
+                        this.featureShutdownTimeout,
+                        `Failed to dispose feature: ${feature.feature.id}`,
+                    );
+                } finally {
+                    clearInterval(intervalId);
+                }
             }
         } finally {
             this.shutingDown = false;


### PR DESCRIPTION
Description of the bug:
The returned callback from `loadEnvironmentConfigurations` never gets called. And only there we remove env from `openEnvironments` map. So the result is envs are still in openEnvironments after being disposed as we only call closeAll that just calls dispose on env.

So I removed the unused callbacks + added openEnvironments.delete(env) when we call closeAll

Note: the tests are failing, so the pr is a draft for now until I fix them
UPD: tests are fixed