### PR TITLE
feat: introduce Feature.configure as an alias to Feature.use

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,7 @@ export default [
             // "no-console": "error",
             'no-empty-pattern': 'off',
             'react/prop-types': 'off',
-            // "react-hooks/rules-of-hooks": "error",
+            "react-hooks/rules-of-hooks": "error",
             'react-hooks/exhaustive-deps': 'error',
             'no-only-tests/no-only-tests': 'error',
 

--- a/examples/file-server/src/fixtures/run.config.ts
+++ b/examples/file-server/src/fixtures/run.config.ts
@@ -4,7 +4,7 @@ import FileServer from '../feature/file-server.feature.js';
  * setting default configuration to the file server service
  */
 export default [
-    FileServer.use({
+    FileServer.configure({
         config: {
             title: 'test',
         },

--- a/examples/file-server/src/test/file-server.it.ts
+++ b/examples/file-server/src/test/file-server.it.ts
@@ -15,7 +15,7 @@ describe('File Server Feature', function () {
             projectPath: path.dirname(__dirname),
         },
         config: [
-            fileServerFeature.use({
+            fileServerFeature.configure({
                 config: {
                     title: 'test-title',
                 },

--- a/examples/multi-env/src/test/multi-env.it.ts
+++ b/examples/multi-env/src/test/multi-env.it.ts
@@ -11,7 +11,7 @@ describe('Multi Environment', () => {
     it('allows providing custom top level config', async () => {
         const { page } = await getLoadedFeature({
             config: [
-                MultiEnv.use({
+                MultiEnv.configure({
                     config: {
                         name: 'my-name',
                     },

--- a/guides/docs/entities/engine.md
+++ b/guides/docs/entities/engine.md
@@ -74,7 +74,7 @@ f.setup(env2, ({ [RUN_OPTIONS]: runOptions, config }) => {
 const runtimeEngine = new RuntimeEngine(
   env1,
   [
-    f.use({
+    f.configure({
       config: {
         name: 'some-name',
       },

--- a/packages/core/src/entities/feature.ts
+++ b/packages/core/src/entities/feature.ts
@@ -64,9 +64,11 @@ export class Feature<T extends string> {
     static context<T extends FeatureClass>(this: T): InstanceType<T>['context'] {
         return instantiateFeature(this).context;
     }
-    static use<T extends FeatureClass>(this: T, c: PartialFeatureConfig<InstanceType<T>['api']>) {
+    static configure<T extends FeatureClass>(this: T, c: PartialFeatureConfig<InstanceType<T>['api']>) {
         return provideConfig(this, c);
     }
+    /** @deprecated use {@link Feature.configure} instead */
+    static use = this.configure;
     static setup<T extends FeatureClass, E extends AnyEnvironment>(
         this: T,
         environment: E,

--- a/packages/core/test/node/env-dependencies.spec.ts
+++ b/packages/core/test/node/env-dependencies.spec.ts
@@ -283,7 +283,7 @@ describe('ENV dependencies', () => {
             entryFeature: TestFeature,
             env: extendingEnv,
             topLevelConfig: [
-                COM.use({
+                COM.configure({
                     config: {
                         host: extEnvHost,
                     },
@@ -295,7 +295,7 @@ describe('ENV dependencies', () => {
             entryFeature: TestFeature,
             env: otherEnv,
             topLevelConfig: [
-                COM.use({
+                COM.configure({
                     config: {
                         host: otherEnvHost,
                     },

--- a/packages/core/test/node/runtime.spec.ts
+++ b/packages/core/test/node/runtime.spec.ts
@@ -279,10 +279,10 @@ describe('Feature', () => {
             const engine = await runEngine({
                 entryFeature,
                 topLevelConfig: [
-                    entryFeature.use({
+                    entryFeature.configure({
                         config: { a: 'a' },
                     }),
-                    entryFeature.use({
+                    entryFeature.configure({
                         config: { b: 'b', c: [1] },
                     }),
                 ],
@@ -317,10 +317,10 @@ describe('Feature', () => {
             const engine = await runEngine({
                 entryFeature,
                 topLevelConfig: [
-                    entryFeature.use({
+                    entryFeature.configure({
                         config: { a: 'a', c: [1] },
                     }),
-                    entryFeature.use({
+                    entryFeature.configure({
                         config: { b: 'b', c: [2] },
                     }),
                 ],
@@ -544,10 +544,10 @@ describe('feature interaction', () => {
         const engine = await runEngine({
             entryFeature,
             topLevelConfig: [
-                entryFeature.use({
+                entryFeature.configure({
                     config: { prefix: '!' },
                 }),
-                entryFeature.use({
+                entryFeature.configure({
                     config: { suffix: '?' },
                 }),
             ],

--- a/packages/engineer/src/feature/dev-server.dev-server.env.ts
+++ b/packages/engineer/src/feature/dev-server.dev-server.env.ts
@@ -130,7 +130,7 @@ devServerFeature.setup(
                         overrideConfig: (envName: string) => {
                             const config = Array.isArray(overrideConfig) ? overrideConfig : overrideConfig(envName);
                             config.push(
-                                RuntimeMetadata.use({
+                                RuntimeMetadata.configure({
                                     engineerMetadataConfig: {
                                         devport: actualPort,
                                         isWorkspace: packages.length > 1,

--- a/packages/engineer/src/utils.ts
+++ b/packages/engineer/src/utils.ts
@@ -54,13 +54,13 @@ export async function startDevServer(options: IStartOptions): Promise<{
         type: 'node',
         host: new BaseHost(),
         config: [
-            devServerFeature.use({
+            devServerFeature.configure({
                 devServerConfig: asDevConfig(serverOpts, engineCnf),
             }),
             ...(options.devServerOnly
                 ? []
                 : [
-                      guiFeature.use({
+                      guiFeature.configure({
                           engineerConfig: {
                               features,
                           },

--- a/packages/runtime-node/src/ipc-environment.ts
+++ b/packages/runtime-node/src/ipc-environment.ts
@@ -13,7 +13,7 @@ export async function runIPCEnvironment(options: StartIPCEnvironmntOptions) {
     disposeHandlers.add(() => host.dispose());
     const config = [
         ...(options.config ?? []),
-        COM.use({
+        COM.configure({
             config: {
                 connectedEnvironments: {
                     [options.parentEnvName]: {

--- a/packages/runtime-node/src/node-environment.ts
+++ b/packages/runtime-node/src/node-environment.ts
@@ -24,7 +24,7 @@ export async function runNodeEnvironment<ENV extends AnyEnvironment>({
 }: StartEnvironmentOptions<ENV>): Promise<RuntimeEngine<ENV>> {
     if (host) {
         config.push(
-            COM.use({
+            COM.configure({
                 config: {
                     host,
                     id: name,
@@ -34,7 +34,7 @@ export async function runNodeEnvironment<ENV extends AnyEnvironment>({
     }
 
     config.push(
-        RuntimeMetadata.use({
+        RuntimeMetadata.configure({
             engineerMetadataConfig: {
                 applicationPath: bundlePath,
             },
@@ -57,7 +57,7 @@ export async function runNodeEnvironment<ENV extends AnyEnvironment>({
     const engine = new RuntimeEngine(
         env,
         [
-            COM.use({
+            COM.configure({
                 config: {
                     resolvedContexts,
                 },

--- a/packages/runtime-node/src/node-environments-manager.ts
+++ b/packages/runtime-node/src/node-environments-manager.ts
@@ -223,7 +223,7 @@ export class NodeEnvironmentsManager {
 
             const config: TopLevelConfig = [];
 
-            config.push(COM.use({ config: { topology, connectedEnvironments } }));
+            config.push(COM.configure({ config: { topology, connectedEnvironments } }));
             config.push(
                 ...(await loadTopLevelConfigs(originalConfigName, this.options.configurations)),
                 ...overrideConfigs,

--- a/packages/runtime-node/src/process-communication.ts
+++ b/packages/runtime-node/src/process-communication.ts
@@ -73,7 +73,7 @@ export function createIPC(
                 ...message.data,
                 config: [
                     ...(message.data.config ?? []),
-                    COM.use({
+                    COM.configure({
                         config: {
                             connectedEnvironments,
                         },

--- a/packages/runtime-node/src/worker-thread-entry.ts
+++ b/packages/runtime-node/src/worker-thread-entry.ts
@@ -27,7 +27,7 @@ const handleStartupMessage = async (command: WorkerThreadStartupCommand) => {
     const host = new UniversalWorkerHost(worker, worker.workerData.name);
 
     config.push(
-        COM.use({
+        COM.configure({
             config: {
                 connectedEnvironments: {
                     [parentEnvName]: {

--- a/packages/runtime-node/test/node-environments-manager.unit.ts
+++ b/packages/runtime-node/test/node-environments-manager.unit.ts
@@ -241,7 +241,7 @@ describe('Node environments manager', function () {
             });
 
             const engine = new RuntimeEngine(env, [
-                COM.use({
+                COM.configure({
                     config: {
                         topology: nodeEnvironmentManager.getTopology('engine-multi-socket-node/x'),
                     },
@@ -313,7 +313,7 @@ describe('Node environments manager', function () {
             );
 
             const engine = new RuntimeEngine(env, [
-                COM.use({
+                COM.configure({
                     config: {
                         topology: nodeEnvironmentManager.getTopology('engine-default-args-echo'),
                     },
@@ -349,7 +349,7 @@ describe('Node environments manager', function () {
             });
 
             const engine = new RuntimeEngine(env, [
-                COM.use({
+                COM.configure({
                     config: {
                         topology: nodeEnvironmentManager.getTopology(engineMultiNodeSocketCommunication.scopedName),
                     },
@@ -410,7 +410,7 @@ describe('Node environments manager', function () {
             });
 
             const engine = new RuntimeEngine(env, [
-                COM.use({
+                COM.configure({
                     config: {
                         topology: nodeEnvironmentManager.getTopology(engineMultiNodeIPCCommunication.scopedName),
                     },
@@ -446,7 +446,7 @@ describe('Node environments manager', function () {
             });
 
             const engine = new RuntimeEngine(env, [
-                COM.use({
+                COM.configure({
                     config: {
                         topology: nodeEnvironmentManager.getTopology(engineMultiNodeIPCCommunication.scopedName),
                     },

--- a/packages/scripts/src/config-middleware.ts
+++ b/packages/scripts/src/config-middleware.ts
@@ -87,7 +87,7 @@ export function createCommunicationMiddleware(
                 topLevelConfig: TopLevelConfig[];
             }
         ).topLevelConfig.concat([
-            COM.use({
+            COM.configure({
                 config: {
                     topology,
                     publicPath,

--- a/packages/scripts/src/create-node-entrypoint.ts
+++ b/packages/scripts/src/create-node-entrypoint.ts
@@ -89,7 +89,7 @@ main({
     options,
     contextualConfig: ({ resolvedContexts }) => {
         return [
-            ...(workerData ? [COM.use({
+            ...(workerData ? [COM.configure({
                 config: {
                     resolvedContexts,
                     host: new ParentPortHost(),

--- a/packages/scripts/src/create-web-entrypoint.ts
+++ b/packages/scripts/src/create-web-entrypoint.ts
@@ -60,7 +60,7 @@ main({
     options,
     contextualConfig: ({ resolvedContexts }) => {
         return [
-            COM.use({
+            COM.configure({
                 config: {
                     publicPath: runtimePublicPath,
                     resolvedContexts,

--- a/packages/scripts/src/run-environment.ts
+++ b/packages/scripts/src/run-environment.ts
@@ -143,7 +143,7 @@ async function runEngineEnvironment<ENV extends AnyEnvironment>({
     com.registerEnv(METADATA_PROVIDER_ENV_ID, metadataProviderHost);
 
     config.push(
-        COM.use({
+        COM.configure({
             config: {
                 connectedEnvironments: {
                     [ENGINE_ROOT_ENVIRONMENT_ID]: {

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -44,7 +44,7 @@ export interface IFeatureModule {
     exportedEnvs: IEnvironmentDescriptor<AnyEnvironment>[];
 
     /**
-     * If module exports any `processingEnv.use('webworker')`,
+     * If module exports any `processingEnv.useContext('webworker')`,
      * it will be set as `'processing': 'webworker'`
      */
     usedContexts?: Record<string, string>;

--- a/test-fixtures/engine-multi-feature/src/fixtures/fixture1.config.ts
+++ b/test-fixtures/engine-multi-feature/src/fixtures/fixture1.config.ts
@@ -1,7 +1,7 @@
 import MultiFeature from '../feature/app.feature.js';
 
 export default [
-    MultiFeature.use({
+    MultiFeature.configure({
         myConfig: { tags: ['fixture1'] },
     }),
 ];

--- a/test-fixtures/engine-multi-feature/src/fixtures/variant/variant1.config.ts
+++ b/test-fixtures/engine-multi-feature/src/fixtures/variant/variant1.config.ts
@@ -1,7 +1,7 @@
 import MultiFeature from '../../feature/app.feature.js';
 
 export default [
-    MultiFeature.use({
+    MultiFeature.configure({
         myConfig: { tags: ['variant', '1'] },
     }),
 ];

--- a/test-fixtures/engine-multi-feature/src/fixtures/variant/variant2.config.ts
+++ b/test-fixtures/engine-multi-feature/src/fixtures/variant/variant2.config.ts
@@ -1,7 +1,7 @@
 import MultiFeature from '../../feature/app.feature.js';
 
 export default [
-    MultiFeature.use({
+    MultiFeature.configure({
         myConfig: { tags: ['variant', '2'] },
     }),
 ];

--- a/test-fixtures/engine-single-feature/src/feature/x.config.ts
+++ b/test-fixtures/engine-single-feature/src/feature/x.config.ts
@@ -1,7 +1,7 @@
 import MyFeature from './x.feature.js';
 
 export default [
-    MyFeature.use({
+    MyFeature.configure({
         config: { value: 0 },
     }),
 ];

--- a/test-fixtures/static-base-web-application/src/base.config.ts
+++ b/test-fixtures/static-base-web-application/src/base.config.ts
@@ -1,7 +1,7 @@
 import BaseWebApplicationFeature from './base-web-application.feature.js';
 
 export default [
-    BaseWebApplicationFeature.use({
+    BaseWebApplicationFeature.configure({
         baseAppConfig: {
             message: 'a configured message',
         },

--- a/test-fixtures/using-config/src/fixtures/alternative.config.ts
+++ b/test-fixtures/using-config/src/fixtures/alternative.config.ts
@@ -1,7 +1,7 @@
 import UseConfigs from '../feature/use-configs.feature.js';
 
 export default [
-    UseConfigs.use({
+    UseConfigs.configure({
         config: {
             echoText: 'gaga',
         },


### PR DESCRIPTION
newer react hooks lint rules now sees this use call and thinks it's a hook call outside of a component introduce Feature.configure to avoid this issue entirely