### PR TITLE
fix(test-kit): tests screenshots path is broken on windows

### DIFF
--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -589,7 +589,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}): WithF
                         if (ctx?.currentTest?.state === 'failed') {
                             const testPath = ctx.currentTest.titlePath().join('/').replace(/\s/g, '-');
                             const filePath = `${outPath}/${testPath}__${uniqueHash()}.png`;
-                            const sanitizedFilePath = filePath.replace(/[<>:"|?*]/g, '-');
+                            const sanitizedFilePath = filePath.replace(/(?<!^[A-Z]):|[<>"|?*]/g, '-');
 
                             await featurePage.screenshot({ path: sanitizedFilePath });
 
@@ -759,7 +759,7 @@ async function enableTracing({
                     name:
                         (process.env.TRACING && process.env.TRACING !== 'true'
                             ? process.env.TRACING
-                            : name ?? (testName ? normalizeTestName(testName) : 'nameless-test')) +
+                            : (name ?? (testName ? normalizeTestName(testName) : 'nameless-test'))) +
                         (process.env.TRACING_POSTFIX ?? ''),
                 }),
             });

--- a/packages/test-kit/src/with-feature.ts
+++ b/packages/test-kit/src/with-feature.ts
@@ -589,7 +589,7 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}): WithF
                         if (ctx?.currentTest?.state === 'failed') {
                             const testPath = ctx.currentTest.titlePath().join('/').replace(/\s/g, '-');
                             const filePath = `${outPath}/${testPath}__${uniqueHash()}.png`;
-                            const sanitizedFilePath = filePath.replace(/(?<!^[A-Z]):|[<>"|?*]/g, '-');
+                            const sanitizedFilePath = sanitizeFilePath(filePath);
 
                             await featurePage.screenshot({ path: sanitizedFilePath });
 
@@ -616,6 +616,15 @@ export function withFeature(withFeatureOptions: IWithFeatureOptions = {}): WithF
 
 export function screenShotMessage(sanitizedFilePath: string): string {
     return `The screenshot has been saved at ${sanitizedFilePath}`;
+}
+
+export function sanitizeFilePath(filePath: string): string {
+    // This is done for windows paths C:\Users\... so we don't replace this : when sanitizing
+    const pathPrefix = filePath.match(/^[A-Z]:[\\/]/)?.[0] ?? '';
+    const pathWithoutPrefix = filePath.slice(pathPrefix.length);
+
+    const sanitizedWithoutPrefix = pathWithoutPrefix.replace(/[:<>"|?*]/g, '-');
+    return `${pathPrefix}${sanitizedWithoutPrefix}`;
 }
 
 async function getMetrics(runningFeature: RunningFeature, featurePage: playwright.Page) {

--- a/packages/test-kit/test/sanitize-file-path.unit.ts
+++ b/packages/test-kit/test/sanitize-file-path.unit.ts
@@ -1,0 +1,25 @@
+import { sanitizeFilePath } from '@wixc3/engine-test-kit';
+import { expect } from 'chai';
+
+describe('Sanitize file path', () => {
+    it('Doesnt damage valid windows paths', () => {
+        const original = 'C:\\Users\\John\\123dogs\\cats';
+        const result = sanitizeFilePath(original);
+        expect(result).to.equal(original);
+    });
+    it('Doesnt damage valid mac paths', () => {
+        const original = '/Users/John/123dogs/cats';
+        const result = sanitizeFilePath(original);
+        expect(result).to.equal(original);
+    });
+    it('Doesnt allow to inject in the disk path', () => {
+        const original = 'C:sfafaf\\Users\\John\\123dogs\\cats';
+        const result = sanitizeFilePath(original);
+        expect(result).to.equal('C-sfafaf\\Users\\John\\123dogs\\cats');
+    });
+    it('Sanitizes path', () => {
+        const original = '/Users:command/<123>John/123?do*gs/cats';
+        const result = sanitizeFilePath(original);
+        expect(result).to.equal('/Users-command/-123-John/123-do-gs/cats');
+    });
+});


### PR DESCRIPTION
Fixes #2545 
Fixes the logic of sanitising the screenshots path. 
The current logic replaces every ':' with a '-' which on windows leads to a path 'C-\Users\...' instead of 'C:\Users\...'. 
This PR adds a lookbehind to the regex so it skips the ':' if it goes after a capital letter which is a first symbol in the path