### PR TITLE
feat: add the message that was rejected by environment disconnection

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -572,7 +572,11 @@ export class Communication {
         delete this.environments[instanceId];
         for (const callbackRecord of this.pendingCallbacks.values()) {
             if (callbackRecord.message.to === instanceId) {
-                callbackRecord.reject(new EnvironmentDisconnectedError(ENV_DISCONNECTED(instanceId, this.rootEnvId)));
+                callbackRecord.reject(
+                    new EnvironmentDisconnectedError(
+                        ENV_DISCONNECTED(instanceId, this.rootEnvId, cleanMessageForLog(callbackRecord.message)),
+                    ),
+                );
             }
         }
         for (const dispose of this.disposeListeners) {

--- a/packages/core/src/com/logs.ts
+++ b/packages/core/src/com/logs.ts
@@ -5,8 +5,8 @@ export const DUPLICATE_REGISTER = (id: string, type: 'RemoteService' | 'Environm
 export const GLOBAL_REF = (id: string) => `Com with id "${id}" is already running.`;
 export const REMOTE_CALL_FAILED = (environment: string, stack?: string) =>
     `Remote call failed in "${environment}"${stack ? `\n${stack}` : ''}`;
-export const ENV_DISCONNECTED = (environment: string, hostId: string) =>
-    `Remote call failed in "${environment}" - environment disconnected at "${hostId}"`;
+export const ENV_DISCONNECTED = (environment: string, hostId: string, message: Message) =>
+    `Remote call failed in "${environment}" - environment disconnected at "${hostId}" for in-flight message:\n${JSON.stringify(message)}`;
 export const UNKNOWN_CALLBACK_ID = (message: Message, hostId: string) =>
     `Unknown callback id "${message.callbackId!}" at "${hostId}" in message:\n${JSON.stringify(message)}`;
 export const CALLBACK_TIMEOUT = (callbackId: string, hostId: string, message: Message) =>
@@ -51,7 +51,6 @@ export const UNHANDLED = (message: Message, hostId: string) =>
 export function reportError(e: unknown) {
     console.error(e);
 }
-
 
 export function UN_CONFIGURED_METHOD(api: string, method: string): string | undefined {
     return `cannot add listener to un-configured method ${api} ${method}`;


### PR DESCRIPTION
This helps to know the source of the message that was in flight while the environment disconnected  