### PR TITLE
refactor(communication): better communication errors

### DIFF
--- a/packages/core/src/com/communication-errors.ts
+++ b/packages/core/src/com/communication-errors.ts
@@ -1,0 +1,61 @@
+import type { Message } from './message-types';
+import { redactArguments } from './helpers';
+
+export class EngineCommunicationError extends Error {
+  constructor(
+    errorMessage: string,
+    public readonly causedBy?: Message,
+  ) {
+    super(errorMessage);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+    if (this.causedBy) {
+      this.causedBy = redactArguments(this.causedBy);
+    }
+  }
+}
+
+export class DuplicateRegistrationError extends EngineCommunicationError {
+  constructor(id: string, type: 'RemoteService' | 'Environment' | 'Listener') {
+    super(`Cannot register ${type} "${id}" twice.`);
+  }
+}
+
+export class UnConfiguredMethodError extends EngineCommunicationError {
+  constructor(api: string, method: string) {
+    super(`Cannot add listener to un-configured method ${api} ${method}.`);
+  }
+}
+
+export class UnknownCallbackIdError extends EngineCommunicationError {
+  constructor(message: Message, hostId: string) {
+    super(`Unknown callback "${message.callbackId!}" at "${hostId}".`, message);
+  }
+}
+
+export class CallbackTimeoutError extends EngineCommunicationError {
+  constructor(callbackId: string, hostId: string, message: Message) {
+    super(`Callback "${callbackId}" timed out at "${hostId}".`, message);
+  }
+}
+
+export class EnvironmentDisconnectedError extends EngineCommunicationError {
+  constructor(environment: string, hostId: string, message: Message) {
+    super(
+      `Remote call failed in "${environment}" - environment disconnected at "${hostId}".`,
+      message,
+    );
+  }
+}
+
+export class CircularForwardingError extends EngineCommunicationError {
+  constructor(message: Message, fromEnv: string, toEnv: string) {
+    super(
+      `Forwarding message from "${fromEnv}" to "${toEnv}" is stuck in circular messaging loop:\n\t${JSON.stringify(
+        message.forwardingChain,
+      )}.
+             This probably happened because you are forwarding a message to an environment that is not connected to the root environment`,
+      message,
+    );
+  }
+}

--- a/packages/core/src/com/environment-disconnected-error.ts
+++ b/packages/core/src/com/environment-disconnected-error.ts
@@ -1,7 +1,0 @@
-export class EnvironmentDisconnectedError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'EnvironmentDisconnectedError';
-        Object.setPrototypeOf(this, new.target.prototype);
-    }
-}

--- a/packages/core/src/com/index.ts
+++ b/packages/core/src/com/index.ts
@@ -10,4 +10,4 @@ export * from './types.js';
 export * from './hosts/ws-client-host.js';
 export * from './initializers/index.js';
 export * from './hosts/index.js';
-export * from './environment-disconnected-error.js';
+export * from './communication-errors.js';

--- a/packages/core/src/com/logs.ts
+++ b/packages/core/src/com/logs.ts
@@ -1,16 +1,8 @@
 import type { Message } from './message-types.js';
 
-export const DUPLICATE_REGISTER = (id: string, type: 'RemoteService' | 'Environment') =>
-    `Could not register same id ${id} as ${type}`;
 export const GLOBAL_REF = (id: string) => `Com with id "${id}" is already running.`;
 export const REMOTE_CALL_FAILED = (environment: string, stack?: string) =>
     `Remote call failed in "${environment}"${stack ? `\n${stack}` : ''}`;
-export const ENV_DISCONNECTED = (environment: string, hostId: string, message: Message) =>
-    `Remote call failed in "${environment}" - environment disconnected at "${hostId}" for in-flight message:\n${JSON.stringify(message)}`;
-export const UNKNOWN_CALLBACK_ID = (message: Message, hostId: string) =>
-    `Unknown callback id "${message.callbackId!}" at "${hostId}" in message:\n${JSON.stringify(message)}`;
-export const CALLBACK_TIMEOUT = (callbackId: string, hostId: string, message: Message) =>
-    `Callback timeout "${callbackId}" at "${hostId}" on message:\n${JSON.stringify(message)}`;
 export const MISSING_ENV = (target: string, environments: string[]) =>
     `Destination environment ${target} is not registered. available environments: [${environments.join(', ')}]`;
 export const MISSING_FORWARD_FOR_MESSAGE = (message: Message) => `Not implemented forward for ${message.type}`;
@@ -31,15 +23,6 @@ export const MESSAGE_FROM_UNKNOWN_ENVIRONMENT = (message: Message, hostId: strin
         message.from
     }" at "${hostId}": ${JSON.stringify(message)}`;
 
-export const FORWARDING_MESSAGE_STUCK_IN_CIRCULAR = (message: Message, fromEnv: string, toEnv: string) =>
-    `forwarding message ${JSON.stringify(
-        message,
-        null,
-        2,
-    )} from "${fromEnv}" to "${toEnv}"\n\t^ is stuck in circular messaging loop ${JSON.stringify(
-        message.forwardingChain,
-    )}. this probably happened because you are forwarding a message to an environment that is not connected to the root environment`;
-
 export const FORWARDING_MESSAGE = (message: Message, fromEnv: string, toEnv: string) =>
     `forwarding message ${JSON.stringify(message)} from ${fromEnv} to ${toEnv}`;
 
@@ -50,12 +33,4 @@ export const UNHANDLED = (message: Message, hostId: string) =>
 
 export function reportError(e: unknown) {
     console.error(e);
-}
-
-export function UN_CONFIGURED_METHOD(api: string, method: string): string | undefined {
-    return `cannot add listener to un-configured method ${api} ${method}`;
-}
-
-export function DOUBLE_REGISTER_ERROR(handlerId: string): string | undefined {
-    return 'Cannot add same listener instance twice ' + handlerId;
 }


### PR DESCRIPTION
1. `cleanMessageForLog` helper moved to `helpers.ts` to be reused both in debug logging of `communication.ts` and communication error creation
2. renamed `environment-disconnected-error.ts` to `communication-errors.ts` and implemented inside base communications error class and custom classes for better messaging and potential to sort through errors in error monitoring solutions.