### PR TITLE
fix: handle error being thrown in shutdown of run

### DIFF
--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -58,7 +58,11 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
             this.running = Promise.all(runPromises);
             await this.running;
         } catch (e) {
-            await this.shutdown();
+            try {
+                await this.shutdown();
+            } catch (e2) {
+                throw new AggregateError([e2], 'Failed to shutdown engine after error in run phase', { cause: e });
+            }
             throw e;
         }
         return this;

--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -61,7 +61,7 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
             try {
                 await this.shutdown();
             } catch (e2) {
-                throw new AggregateError([e2], 'Failed to shutdown engine after error in run phase', { cause: e });
+                throw new AggregateError([e, e2], 'Failed to shutdown engine after error in run phase');
             }
             throw e;
         }
@@ -90,8 +90,11 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
                 ).toFixed(2)}s`,
             );
         }, 15000);
-        await featureInstance[RUN](this);
-        clearInterval(intervalId);
+        try {
+            await featureInstance[RUN](this);
+        } finally {
+            clearInterval(intervalId);
+        }
     }
 
     public shutdown = async () => {


### PR DESCRIPTION
when the `catch` scope is being triggered in the `run` function, the catch will execute:
```
await this.shutdown();
```

If shutdown fails for some reason we have no information of what happened.
Adding an extra catch is for adding the missing information.