### PR TITLE
feat(engine-config): introduce "import" field

### DIFF
--- a/packages/scripts/src/resolve-exec-argv.ts
+++ b/packages/scripts/src/resolve-exec-argv.ts
@@ -13,6 +13,12 @@ export async function resolveExecArgv(basePath: string) {
             execArgv.push('-r', pathToRequire);
         }
     }
+    if (config?.import) {
+        for (const pathToImport of config.import) {
+            // https://nodejs.org/api/cli.html#--importmodule
+            execArgv.push('--import', pathToImport);
+        }
+    }
     if (config?.buildConditions) {
         for (const condition of config.buildConditions) {
             // https://nodejs.org/api/cli.html#-c-condition---conditionscondition

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -83,6 +83,7 @@ export type CliFlag<T> = {
 
 export interface EngineConfig {
     require?: string[];
+    import?: string[];
     featureDiscoveryRoot?: string;
     /** relative path to the location of engine features (packages) */
     featuresDirectory?: string;


### PR DESCRIPTION
like require, but uses `--import` instead of `--require`