### PR TITLE
refactor: use node apis directly where possible

### DIFF
--- a/packages/engine-cli/src/analyze-command.ts
+++ b/packages/engine-cli/src/analyze-command.ts
@@ -1,4 +1,4 @@
-import fs from '@file-services/node';
+import { nodeFs as fs } from '@file-services/node';
 import { EngineConfig, analyzeFeatures } from '@wixc3/engine-scripts';
 
 export async function analyzeCommand({

--- a/packages/engine-cli/src/cli.ts
+++ b/packages/engine-cli/src/cli.ts
@@ -2,7 +2,7 @@ import { cli, command } from 'cleye';
 import { analyzeCommand } from './analyze-command';
 import type { EngineConfig } from '@wixc3/engine-scripts';
 import { generateFeature } from './feature-generator';
-import fs from '@file-services/node';
+import { nodeFs as fs } from '@file-services/node';
 
 async function engine() {
     const engineConfigCli = cli({

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -1,4 +1,4 @@
-import fs from '@file-services/node';
+import { nodeFs as fs } from '@file-services/node';
 import {
     ConfigurationEnvironmentMapping,
     FeatureEnvironmentMapping,

--- a/packages/engine-cli/src/entrypoint-files.ts
+++ b/packages/engine-cli/src/entrypoint-files.ts
@@ -1,35 +1,35 @@
-import fs from '@file-services/node';
-import { join } from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { EntryPointsPaths, EntryPoints } from './create-entrypoints';
 
 export function writeEntryPoints(dir: string, { nodeEntryPoints, webEntryPoints }: EntryPoints): EntryPointsPaths {
-    const outDirWeb = join(dir, 'entrypoints', 'web');
-    const outDirNode = join(dir, 'entrypoints', 'node');
+    const outDirWeb = path.join(dir, 'entrypoints', 'web');
+    const outDirNode = path.join(dir, 'entrypoints', 'node');
     fs.mkdirSync(outDirWeb, { recursive: true });
     fs.mkdirSync(outDirNode, { recursive: true });
     const webEntryPointsPaths = [];
     const nodeEntryPointsPaths = [];
     for (const [name, content] of webEntryPoints) {
-        const path = join(outDirWeb, name);
-        webEntryPointsPaths.push(path);
-        fs.writeFileSync(path, content);
+        const entryFilePath = path.join(outDirWeb, name);
+        webEntryPointsPaths.push(entryFilePath);
+        fs.writeFileSync(entryFilePath, content);
     }
     for (const [name, content] of nodeEntryPoints) {
-        const path = join(outDirNode, name);
-        nodeEntryPointsPaths.push(path);
-        fs.writeFileSync(path, content);
+        const entryFilePath = path.join(outDirNode, name);
+        nodeEntryPointsPaths.push(entryFilePath);
+        fs.writeFileSync(entryFilePath, content);
     }
     return { webEntryPointsPaths, nodeEntryPointsPaths };
 }
 
 export function readEntryPoints(dir: string): (EntryPoints & EntryPointsPaths) | undefined {
     try {
-        const webDir = join(dir, 'entrypoints', 'web');
-        const nodeDir = join(dir, 'entrypoints', 'node');
+        const webDir = path.join(dir, 'entrypoints', 'web');
+        const nodeDir = path.join(dir, 'entrypoints', 'node');
         const webEntryPoints = readDirShallowIntoMap(webDir);
         const nodeEntryPoints = readDirShallowIntoMap(nodeDir);
-        const webEntryPointsPaths = Array.from(webEntryPoints.keys()).map((name) => join(webDir, name));
-        const nodeEntryPointsPaths = Array.from(nodeEntryPoints.keys()).map((name) => join(nodeDir, name));
+        const webEntryPointsPaths = Array.from(webEntryPoints.keys()).map((name) => path.join(webDir, name));
+        const nodeEntryPointsPaths = Array.from(nodeEntryPoints.keys()).map((name) => path.join(nodeDir, name));
         return { webEntryPoints, nodeEntryPoints, webEntryPointsPaths, nodeEntryPointsPaths };
     } catch {
         return undefined;
@@ -38,7 +38,7 @@ export function readEntryPoints(dir: string): (EntryPoints & EntryPointsPaths) |
 
 function readDirShallowIntoMap(dir: string) {
     return fs.readdirSync(dir).reduce((acc, name) => {
-        acc.set(name, fs.readFileSync(join(dir, name), 'utf-8'));
+        acc.set(name, fs.readFileSync(path.join(dir, name), 'utf-8'));
         return acc;
     }, new Map<string, string>());
 }

--- a/packages/engine-cli/src/esbuild-html-plugin.ts
+++ b/packages/engine-cli/src/esbuild-html-plugin.ts
@@ -1,5 +1,6 @@
-import fs from '@file-services/node';
-import { Plugin } from 'esbuild';
+import type { Plugin } from 'esbuild';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export interface HTMLPluginOptions {
     toHtmlPath?: (fileName: string) => string;
@@ -29,16 +30,16 @@ export function htmlPlugin({
                 if (!metafile) {
                     throw new Error('metafile must be set when using html-plugin');
                 }
-                const iconName = faviconFilePath ? fs.basename(faviconFilePath) : 'favicon.ico';
+                const iconName = faviconFilePath ? path.basename(faviconFilePath) : 'favicon.ico';
                 const cwd = build.initialOptions.absWorkingDir || process.cwd();
                 for (const [key, meta] of Object.entries(metafile.outputs)) {
                     if (!key.match(/\.m?js$/)) {
                         continue;
                     }
-                    const fileName = fs.basename(key);
-                    const jsDir = fs.dirname(key);
-                    const htmlFile = fs.join(jsDir, toHtmlPath(fileName));
-                    const cssPath = meta.cssBundle ? fs.basename(meta.cssBundle) : undefined;
+                    const fileName = path.basename(key);
+                    const jsDir = path.dirname(key);
+                    const htmlFile = path.join(jsDir, toHtmlPath(fileName));
+                    const cssPath = meta.cssBundle ? path.basename(meta.cssBundle) : undefined;
                     const htmlContent = deindento(`
                         |<!DOCTYPE html>
                         |<html>
@@ -55,9 +56,9 @@ export function htmlPlugin({
                         |</html>
                     `);
                     if (faviconFilePath) {
-                        fs.copyFileSync(faviconFilePath, fs.join(cwd, jsDir, iconName));
+                        fs.copyFileSync(faviconFilePath, path.join(cwd, jsDir, iconName));
                     }
-                    fs.writeFileSync(fs.join(cwd, htmlFile), htmlContent);
+                    fs.writeFileSync(path.join(cwd, htmlFile), htmlContent);
                 }
                 return null;
             });

--- a/packages/engine-cli/src/launch-dashboard-server.ts
+++ b/packages/engine-cli/src/launch-dashboard-server.ts
@@ -1,8 +1,8 @@
-import fs from '@file-services/node';
+import { nodeFs as fs } from '@file-services/node';
 import { ConfigurationEnvironmentMapping, FeatureEnvironmentMapping } from '@wixc3/engine-runtime-node';
 import { StaticConfig } from '@wixc3/engine-scripts';
 import express from 'express';
-import { json } from 'body-parser';
+import bodyParser from 'body-parser';
 import { LaunchOptions, RouteMiddleware, launchServer } from './start-dev-server';
 import { join } from 'node:path';
 import { runLocalNodeManager } from './run-local-mode-manager';
@@ -75,7 +75,7 @@ export async function launchDashboardServer(
         },
         {
             path: '/api/engine/run',
-            handlers: [json(), middleware],
+            handlers: [bodyParser.json(), middleware],
         },
         {
             path: '/api/engine/analyze',

--- a/packages/engine-cli/src/resolve-runtime-options.ts
+++ b/packages/engine-cli/src/resolve-runtime-options.ts
@@ -1,5 +1,5 @@
-import fs from '@file-services/node';
-import { TopLevelConfig } from '@wixc3/engine-core';
+import type { TopLevelConfig } from '@wixc3/engine-core';
+import path from 'node:path';
 
 export interface RunNodeManagerOptions {
     outputPath: string;
@@ -19,7 +19,7 @@ export function resolveRuntimeOptions({
     topLevelConfig,
 }: RunNodeManagerOptions) {
     const runtimeOptions = new Map<string, string | boolean | undefined>();
-    runtimeOptions.set('applicationPath', fs.join(outputPath, 'web'));
+    runtimeOptions.set('applicationPath', path.join(outputPath, 'web'));
     runtimeOptions.set('feature', featureName);
     if (verbose) {
         runtimeOptions.set('verbose', 'true');

--- a/packages/engine-cli/src/start-dev-server.ts
+++ b/packages/engine-cli/src/start-dev-server.ts
@@ -1,7 +1,7 @@
 import cors from 'cors';
 import { safeListeningHttpServer } from 'create-listening-server';
 import express from 'express';
-import io from 'socket.io';
+import * as io from 'socket.io';
 
 const noContentHandler: express.RequestHandler = (_req, res) => {
     res.status(204); // No Content

--- a/packages/runtime-node/src/metadata-files.ts
+++ b/packages/runtime-node/src/metadata-files.ts
@@ -1,18 +1,20 @@
-import fs from '@file-services/node';
-import { join } from 'node:path';
-import {
-    type ConfigurationEnvironmentMapping,
-    type FeatureEnvironmentMapping,
-    type createFeatureEnvironmentsMapping,
+import fs from 'node:fs';
+import path from 'node:path';
+import type {
+    ConfigurationEnvironmentMapping,
+    FeatureEnvironmentMapping,
+    createFeatureEnvironmentsMapping,
 } from './node-env-manager';
 
 export function readMetadataFiles(dir: string) {
     try {
-        const featureEnvironmentsMapping = fs.readJsonFileSync(
-            join(dir, 'metadata', 'engine-feature-environments-mapping.json'),
-        ) as ReturnType<typeof createFeatureEnvironmentsMapping>;
-        const configMapping = fs.readJsonFileSync(
-            join(dir, 'metadata', 'engine-config-mapping.json'),
+        const envMappingFilePath = path.join(dir, 'metadata', 'engine-feature-environments-mapping.json');
+        const featureEnvironmentsMapping = JSON.parse(fs.readFileSync(envMappingFilePath, 'utf8')) as ReturnType<
+            typeof createFeatureEnvironmentsMapping
+        >;
+        const engineConfigMappingFilePath = path.join(dir, 'metadata', 'engine-config-mapping.json');
+        const configMapping = JSON.parse(
+            fs.readFileSync(engineConfigMappingFilePath, 'utf8'),
         ) as ConfigurationEnvironmentMapping;
         return { featureEnvironmentsMapping, configMapping };
     } catch {
@@ -25,11 +27,11 @@ export function writeMetaFiles(
     featureEnvironmentsMapping: FeatureEnvironmentMapping,
     configMapping: ConfigurationEnvironmentMapping,
 ) {
-    const outDir = join(dir, 'metadata');
+    const outDir = path.join(dir, 'metadata');
     fs.mkdirSync(outDir, { recursive: true });
     fs.writeFileSync(
-        join(outDir, 'engine-feature-environments-mapping.json'),
+        path.join(outDir, 'engine-feature-environments-mapping.json'),
         JSON.stringify(featureEnvironmentsMapping, null, 2),
     );
-    fs.writeFileSync(join(outDir, 'engine-config-mapping.json'), JSON.stringify(configMapping, null, 2));
+    fs.writeFileSync(path.join(outDir, 'engine-config-mapping.json'), JSON.stringify(configMapping, null, 2));
 }

--- a/packages/test-kit/src/link-test-dir.ts
+++ b/packages/test-kit/src/link-test-dir.ts
@@ -1,11 +1,12 @@
-import fs from '@file-services/node';
+import fs from 'node:fs';
+import path from 'node:path';
 /**
  * This function links node_modules from a path to the project.
  * This has a BROKEN/QUESTIONABLE mechanism to handle packages that was inside the workspace
  * This will break if there will be confecting packages in root and package.
  */
 export const linkNodeModules = (toPath: string, fromNodeModules: string) => {
-    const targetNodeModules = fs.join(toPath, 'node_modules');
+    const targetNodeModules = path.join(toPath, 'node_modules');
     if (fs.existsSync(targetNodeModules)) {
         const items = fs.readdirSync(targetNodeModules);
         // happens because the project path exists in the workspaces of the root package.json


### PR DESCRIPTION
- no need for file-services in places that import file-services/node directly and dont use the extended APIs
- import-style fixes for native esm