### PR TITLE
refactor(config): correct OverrideConfigHook type

### DIFF
--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -187,6 +187,7 @@ export async function runEngine({
             }
             const { buildEndPlugin, waitForBuildEnd, waitForRebuild } = createBuildEndPluginHook();
             waitForWebRebuild = waitForRebuild;
+            buildConfigurations.webConfig.plugins ??= [];
             buildConfigurations.webConfig.plugins.push(buildEndPlugin);
             esbuildContextWeb = await esbuild.context(buildConfigurations.webConfig);
             // TODO: use our own watch system to avoid duplicate watchers
@@ -202,6 +203,7 @@ export async function runEngine({
                 console.log('Starting node compilation in watch mode');
             }
             const { buildEndPlugin, waitForBuildEnd } = createBuildEndPluginHook();
+            buildConfigurations.nodeConfig.plugins ??= [];
             buildConfigurations.nodeConfig.plugins.push(buildEndPlugin);
             esbuildContextNode = await esbuild.context(buildConfigurations.nodeConfig);
             // TODO: use our own watch system to avoid duplicate watchers

--- a/packages/engine-cli/src/types.ts
+++ b/packages/engine-cli/src/types.ts
@@ -70,7 +70,7 @@ export type BuildConfiguration = {
     dev: boolean;
 };
 
-export type OverrideConfigHook = <const T extends BuildConfiguration>(config: T) => T;
+export type OverrideConfigHook = (config: BuildConfiguration) => BuildConfiguration;
 
 export type CliFlag<T> = {
     /** e.g. String, Boolean, etc. */


### PR DESCRIPTION
ensure it allows passing in functions without warning about T being able to instantiate with an extended type