### PR TITLE
feat(iframe): get run option from parent

### DIFF
--- a/examples/cross-iframe/src/test/cross-iframe-driver.ts
+++ b/examples/cross-iframe/src/test/cross-iframe-driver.ts
@@ -12,6 +12,10 @@ export class CrossIframeDriver {
         return this.page.locator(`button.init-iframe-button-${index}`).click();
     }
 
+    public clickNavigationButtonByTestId(testId: string) {
+        return this.page.locator(`button#${testId}`).click();
+    }
+
     public getIframeContent() {
         const iframe = this.page.frameLocator('iframe');
         const iframeBody = iframe.locator('body');

--- a/examples/cross-iframe/src/test/cross-iframe.it.ts
+++ b/examples/cross-iframe/src/test/cross-iframe.it.ts
@@ -59,4 +59,13 @@ describe('Cross Iframes Example', function () {
         await crossFrameDriver.clickNavigationButton(0);
         await waitFor(async () => expect(await crossFrameDriver.getIframeContent()).to.eq('iframe/4'));
     });
+
+    it('initial iframe rendered and then iframe that fetches run options from parent', async () => {
+        const { page } = await getLoadedFeature();
+        const crossFrameDriver = await CrossIframeDriver.getFromRoot(page);
+
+        await waitFor(async () => expect(await crossFrameDriver.getIframeContent()).to.eq('iframe/0'));
+        await crossFrameDriver.clickNavigationButtonByTestId('fetch-from-parent');
+        await waitFor(async () => expect(await crossFrameDriver.getIframeContent()).to.eq('iframe/1'));
+    });
 });

--- a/packages/core/src/runtime-main.ts
+++ b/packages/core/src/runtime-main.ts
@@ -77,14 +77,8 @@ async function getRunningOptionsFromParent(options: IRunOptions) {
     }
 
     return await new Promise<IRunOptions>((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
-            window.removeEventListener('message', listenForEnvId);
-            reject(new Error('Parent window did not respond with running options'));
-        }, 5000);
-
         function listenForEnvId(evt: MessageEvent) {
             if ('kind' in evt.data && evt.data.kind === RUN_OPTIONS_PROVIDED_KIND) {
-                clearTimeout(timeoutId);
                 window.removeEventListener('message', listenForEnvId);
                 const paramsFromParent = new URLSearchParams(evt.data.runOptionsParams);
                 for (const [key, value] of options) {

--- a/packages/core/src/runtime-main.ts
+++ b/packages/core/src/runtime-main.ts
@@ -71,9 +71,20 @@ export async function main({
  * @returns promise with combined options
  */
 async function getRunningOptionsFromParent(options: IRunOptions) {
-    return await new Promise<IRunOptions>((resolve) => {
+    if (window.parent === window) {
+        // if there is no parent window then we assume intentional usage of the env
+        return options;
+    }
+
+    return await new Promise<IRunOptions>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+            window.removeEventListener('message', listenForEnvId);
+            reject(new Error('Parent window did not respond with running options'));
+        }, 5000);
+
         function listenForEnvId(evt: MessageEvent) {
             if ('kind' in evt.data && evt.data.kind === RUN_OPTIONS_PROVIDED_KIND) {
+                clearTimeout(timeoutId);
                 window.removeEventListener('message', listenForEnvId);
                 const paramsFromParent = new URLSearchParams(evt.data.runOptionsParams);
                 for (const [key, value] of options) {

--- a/packages/core/src/runtime-main.ts
+++ b/packages/core/src/runtime-main.ts
@@ -76,7 +76,7 @@ async function getRunningOptionsFromParent(options: IRunOptions) {
         return options;
     }
 
-    return await new Promise<IRunOptions>((resolve, reject) => {
+    return await new Promise<IRunOptions>((resolve) => {
         function listenForEnvId(evt: MessageEvent) {
             if ('kind' in evt.data && evt.data.kind === RUN_OPTIONS_PROVIDED_KIND) {
                 window.removeEventListener('message', listenForEnvId);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -221,3 +221,6 @@ export enum LogLevel {
     WARN,
     ERROR,
 }
+
+export const RUN_OPTIONS_REQUESTED_KIND = 'engine-run-options-requested';
+export const RUN_OPTIONS_PROVIDED_KIND = 'engine-run-options-provided';


### PR DESCRIPTION
now, it will be possible to add to the iframe
```
<script data-engine-run-options="fetch-options-from-parent=true" src="./preview.web.js"></script>
```
or start the iframe with src of `./preview.web.js?fetch-options-from-parent=true`
then use `installRunOptionsInitMessageHandler` on the side of the parent window to have a working iframe env.

It will be used to decouple id generation from iframe dom node creation.



Note: iframe initialization in the engine since we have a [tech debt here](https://github.com/wixplosives/codux/issues/24381). We have an initializer directly in codux and we need to move it back to make sense.