### PR TITLE
feat(core): support feature optional dependencies

### DIFF
--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -75,9 +75,9 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
         const toProcess = [...entryDeps];
         while (toProcess.length) {
             const feature = toProcess.shift()!;
-            if (this.allRequiredFeatures.has(feature.id)) continue;
             this.allRequiredFeatures.add(feature.id);
             for (const dep of feature.dependencies()) {
+                if (this.allRequiredFeatures.has(dep.id)) continue;
                 toProcess.push(dep);
             }
         }

--- a/packages/core/src/runtime-engine.ts
+++ b/packages/core/src/runtime-engine.ts
@@ -12,6 +12,7 @@ import type { IRunOptions, TopLevelConfig } from './types.js';
 
 export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
     public features = new Map<FeatureClass, RuntimeFeature<any, ENV>>();
+    public allRequiredFeatures = new Set<string>();
     public referencedEnvs: Set<string>;
     private running: Promise<void[]> | undefined;
     private shutingDown = false;
@@ -46,6 +47,7 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
         if (!Array.isArray(features)) {
             features = [features];
         }
+        this.preRun(features);
         try {
             for (const feature of features) {
                 this.initFeature(feature);
@@ -66,6 +68,19 @@ export class RuntimeEngine<ENV extends AnyEnvironment = AnyEnvironment> {
             throw e;
         }
         return this;
+    }
+
+    private preRun(entryDeps: FeatureClass[]) {
+        // populate required features
+        const toProcess = [...entryDeps];
+        while (toProcess.length) {
+            const feature = toProcess.shift()!;
+            if (this.allRequiredFeatures.has(feature.id)) continue;
+            this.allRequiredFeatures.add(feature.id);
+            for (const dep of feature.dependencies()) {
+                toProcess.push(dep);
+            }
+        }
     }
 
     public initFeature<T extends FeatureClass>(feature: T): RuntimeFeature<T, ENV> {

--- a/packages/core/test/node/api-type-check.spec.ts
+++ b/packages/core/test/node/api-type-check.spec.ts
@@ -88,7 +88,7 @@ typeCheck((_: EQUAL<SomeApiPromisified, { someMethod(): Promise<boolean> }>) => 
 typeCheck(
     (
         _runningDependencies: EQUAL<
-            RunningFeatures<GUI['dependencies'], typeof MAIN>,
+            RunningFeatures<GUI['dependencies'], GUI['optionalDependencies'], typeof MAIN>,
             { logger: Running<typeof Logger, typeof MAIN> }
         >,
         _runningFeature: EQUAL<
@@ -131,7 +131,7 @@ typeCheck(
             }
         >,
         _runningDependencies: EQUAL<
-            RunningFeatures<AddPanel['dependencies'], typeof MAIN>,
+            RunningFeatures<AddPanel['dependencies'], AddPanel['optionalDependencies'], typeof MAIN>,
             {
                 logger: Running<typeof Logger, typeof MAIN>;
                 gui: Running<typeof GUI, typeof MAIN>;


### PR DESCRIPTION
This PR introduces an `optionalDependencies` configuration option for defining features. 

Optional dependencies will only be initialized and made available if another feature includes them in its (required) `dependencies` definition. This ensures that a feature can leverage another feature dynamically, based on its availability in the current running "flavor."