### PR TITLE
fix(web): getEngineEntryOptions in <script type="module" />

### DIFF
--- a/examples/iframe-env-from-script/package.json
+++ b/examples/iframe-env-from-script/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@example/iframe-env-from-script",
+  "version": "49.3.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "engine --dev",
+    "test": "npm run test:it",
+    "test:it": "mocha \"dist/test/**/*.it.js\""
+  }
+}

--- a/examples/iframe-env-from-script/src/feature/env-from-script.feature.ts
+++ b/examples/iframe-env-from-script/src/feature/env-from-script.feature.ts
@@ -1,0 +1,14 @@
+import { COM, Environment, Feature, Service } from '@wixc3/engine-core';
+export const mainEnv = new Environment('main', 'window', 'single');
+export const iframeEnv = new Environment('iframe', 'iframe', 'multi');
+export interface IEchoService {
+    echo(): void;
+}
+
+export default class IframeEnvFromScript extends Feature<'iframe-env-from-script'> {
+    id = 'iframe-env-from-script' as const;
+    api = {
+        echoService: Service.withType<IEchoService>().defineEntity(iframeEnv).allowRemoteAccess(),
+    };
+    dependencies = [COM];
+}

--- a/examples/iframe-env-from-script/src/feature/env-from-script.iframe.env.ts
+++ b/examples/iframe-env-from-script/src/feature/env-from-script.iframe.env.ts
@@ -1,0 +1,17 @@
+import IframeEnvFromScript, { iframeEnv } from './env-from-script.feature.js';
+
+IframeEnvFromScript.setup(iframeEnv, ({}, {}) => {
+    const p = document.createElement('p');
+    p.appendChild(document.createTextNode('iframe initialized'));
+    document.body.appendChild(p);
+
+    return {
+        echoService: {
+            echo() {
+                const p = document.createElement('p');
+                p.appendChild(document.createTextNode('echo'));
+                document.body.appendChild(p);
+            },
+        },
+    };
+});

--- a/examples/iframe-env-from-script/src/feature/env-from-script.main.env.ts
+++ b/examples/iframe-env-from-script/src/feature/env-from-script.main.env.ts
@@ -1,0 +1,37 @@
+import { installRunOptionsInitMessageHandler } from '@wixc3/engine-core';
+import IframeEnvFromScript, { mainEnv } from './env-from-script.feature.js';
+
+IframeEnvFromScript.setup(mainEnv, ({ run, echoService }, { COM }) => {
+    const echoButton = document.createElement('button');
+    echoButton.id = 'echo';
+    echoButton.innerText = 'echo';
+    document.body.append(echoButton);
+
+    run(async () => {
+        const instanceId = 'iframe-env/0';
+        const iframe = document.createElement('iframe');
+        iframe.srcdoc = `<html>
+        <body>
+        <script defer="" type="module" src="http://localhost:3000/iframe.web.js" data-engine-run-options="fetch-options-from-parent=true"></script>
+        </body>
+        </html>`;
+        document.body.appendChild(iframe);
+        const contentWindow = iframe.contentWindow!;
+        const cleanUp = installRunOptionsInitMessageHandler(contentWindow, () => {
+            cleanUp();
+            const parentParams = new URLSearchParams(window.location.search);
+            return new URLSearchParams({
+                feature: parentParams.get('feature')!,
+                'iframe-instance-id': instanceId,
+            });
+        });
+
+        const com = COM.communication;
+        com.registerEnv(instanceId, contentWindow);
+        await com.envReady(instanceId);
+
+        echoButton.onclick = async () => {
+            await echoService.get({ id: instanceId }).echo();
+        };
+    });
+});

--- a/examples/iframe-env-from-script/src/test/env-from-script.it.ts
+++ b/examples/iframe-env-from-script/src/test/env-from-script.it.ts
@@ -1,0 +1,25 @@
+import { withFeature } from '@wixc3/engine-test-kit';
+import { expect } from 'chai';
+import { waitFor } from 'promise-assist';
+
+describe('iframe created via script and fetch-options-from-parent=true', () => {
+    const { getLoadedFeature } = withFeature({
+        featureName: 'iframe-env-from-script/env-from-script',
+    });
+
+    it('to initialize', async () => {
+        const { page } = await getLoadedFeature();
+        const echoBtn = page.locator('#echo');
+
+        const frameLocator = page.frameLocator('iframe').locator('body');
+        await waitFor(async () => {
+            expect(await frameLocator.getByText('iframe initialized').count()).to.eql(1);
+        });
+
+        await echoBtn.click();
+
+        await waitFor(async () => {
+            expect(await frameLocator.getByText('echo').count()).to.eql(1);
+        });
+    });
+});

--- a/examples/iframe-env-from-script/src/tsconfig.json
+++ b/examples/iframe-env-from-script/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.test.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [{ "path": "../../../packages/core/src" }, { "path": "../../../packages/test-kit/src" }]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,10 @@
         "@file-services/node": "^9.4.1"
       }
     },
+    "examples/iframe-env-from-script": {
+      "name": "@example/iframe-env-from-script",
+      "version": "49.3.0"
+    },
     "examples/multi-env": {
       "name": "@example/multi-env",
       "version": "49.3.0",
@@ -628,6 +632,10 @@
     },
     "node_modules/@example/file-server": {
       "resolved": "examples/file-server",
+      "link": true
+    },
+    "node_modules/@example/iframe-env-from-script": {
+      "resolved": "examples/iframe-env-from-script",
       "link": true
     },
     "node_modules/@example/multi-env": {

--- a/packages/core/src/helpers/web.ts
+++ b/packages/core/src/helpers/web.ts
@@ -28,10 +28,11 @@ interface EngineWebEntryGlobalObj {
 export function getEngineEntryOptions(envName: string, globalObj: EngineWebEntryGlobalObj): IRunOptions {
     const urlParams = new URLSearchParams(globalObj?.location?.search);
     const currentScript =
-        (globalObj?.document?.currentScript ?? (typeof import.meta !== 'undefined' && import.meta.url))
+        globalObj?.document?.currentScript ??
+        (typeof import.meta !== 'undefined' && import.meta.url
             ? // if env run as a module then in has no access to currentScript, in this case we find script by src
               globalObj?.document?.querySelector?.<HTMLElement>(`script[src="${import.meta.url}"]`)
-            : undefined;
+            : undefined);
 
     const optionsFromScript = new URLSearchParams(
         (currentScript && currentScript.dataset.engineRunOptions) || undefined,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     { "path": "./examples/file-server/src" },
     { "path": "./examples/multi-env/src" },
     { "path": "./examples/cross-iframe/src" },
+    { "path": "./examples/iframe-env-from-script/src" },
     { "path": "./examples/node-only/src" },
     { "path": "./examples/playground/src" },
     { "path": "./examples/react/src" },


### PR DESCRIPTION
fix getEngineEntryOptions to be able to get run options from `<script type="module" src="....user-build-preview.web.js" data-engine-run-options="fetch-options-from-parent=true&amp;publicPath=http%3A%2F%2F127.0.0.1%3A62312%2Fcodux-application-dist%2F"></script>`

type="module" makes `document.currentScript` to be `undefined`