### PR TITLE
feat: enhance dashboard server launch with correct entry point logging

### DIFF
--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -272,6 +272,7 @@ export async function runEngine({
             waitForWebRebuild,
             buildConditions,
             extensions,
+            buildConfigurations,
         );
         if (watch) {
             writeWatchSignal(outputPath, { isAliveUrl: `http://localhost:${devServer.port}/is_alive` });

--- a/packages/engine-cli/src/launch-dashboard-server.ts
+++ b/packages/engine-cli/src/launch-dashboard-server.ts
@@ -1,11 +1,11 @@
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { nodeFs as fs } from '@file-services/node';
 import { ConfigurationEnvironmentMapping, FeatureEnvironmentMapping } from '@wixc3/engine-runtime-node';
 import express from 'express';
 import { LaunchOptions, RouteMiddleware, launchServer } from './start-dev-server.js';
 import { runLocalNodeManager } from './run-local-mode-manager.js';
 import { NodeConfigManager } from './node-config-manager.js';
-import type { StaticConfig } from './types.js';
+import type { BuildConfiguration, StaticConfig } from './types.js';
 
 export type ConfigLoadingMode = 'fresh' | 'watch' | 'import';
 
@@ -23,6 +23,7 @@ export async function launchDashboardServer(
     waitForBuildReady?: (cb: () => void) => boolean,
     buildConditions?: string[],
     extensions?: string[],
+    buildConfiguration?: BuildConfiguration,
 ): Promise<ReturnType<typeof launchServer>> {
     const staticMiddlewares = serveStatic.map(({ route, directoryPath }) => ({
         path: route,
@@ -43,8 +44,16 @@ export async function launchDashboardServer(
     const autoRunFeatureName = runtimeOptions.get('feature') as string | undefined;
     if (autoRunFeatureName) {
         const port = await run(autoRunFeatureName, runtimeOptions.get('config') as string, '');
-        // TODO: get the names of main entry points from the build configurations
-        console.log(`Engine application in running at http://localhost:${port}/main.html`);
+        if (Array.isArray(buildConfiguration?.webConfig.entryPoints)) {
+            buildConfiguration?.webConfig.entryPoints?.map((filePath) => {
+                if (typeof filePath === 'string') {
+                    const name = basename(filePath);
+                    console.log(
+                        `Engine application in running at http://localhost:${port}/${name.replace('.web.ts', '.html')}`,
+                    );
+                }
+            });
+        }
     } else {
         console.log('No explicit feature name provided skipping auto launch use the dashboard to run features');
     }

--- a/packages/engine-cli/src/types.ts
+++ b/packages/engine-cli/src/types.ts
@@ -68,7 +68,7 @@ export interface StaticConfig {
 export type BuildConfiguration = {
     webConfig: BuildOptions;
     nodeConfig: BuildOptions;
-    dev: boolean;
+    dev?: boolean;
 };
 
 export type OverrideConfigHook = (config: BuildConfiguration) => BuildConfiguration;


### PR DESCRIPTION
This fix the issue of always showing main.html env in log