### PR TITLE
fix: remove dispatchers from their registration when we clear an environment

### DIFF
--- a/packages/core/src/com/communication-errors.ts
+++ b/packages/core/src/com/communication-errors.ts
@@ -23,7 +23,7 @@ export class DuplicateRegistrationError extends EngineCommunicationError {
 
 export class UnConfiguredMethodError extends EngineCommunicationError {
     constructor(api: string, method: string) {
-        super(`Cannot add listener to un-configured method ${api} ${method}.`);
+        super(`Cannot add listener to un-configured method ${api} ${method}. use "declareComEmitter" to configure it.`);
     }
 }
 

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -990,8 +990,11 @@ export function declareComEmitter<T>(
     if (typeof onMethod !== 'string') {
         throw new Error('onMethod ref must be a string');
     }
+    if (typeof offMethod !== 'string') {
+        throw new Error('offMethod ref must be a string');
+    }
     return {
-        [onMethod]: { listener: true },
+        [onMethod]: { listener: true, removeListener: offMethod },
         [offMethod]: { removeListener: onMethod },
         ...(removeAll ? { [removeAll]: { removeAllListeners: onMethod } } : undefined),
     };

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -574,7 +574,9 @@ export class Communication {
         for (const [dispatcherKey, { message, dispatcher }] of this.eventDispatchers) {
             if (dispatcherKey.endsWith(instanceId)) {
                 this.eventDispatchers.delete(dispatcherKey);
-                this.apiCall(message.origin, message.data.api, message.removeListener, [dispatcher]);
+                if (message.removeListener) {
+                    this.apiCall(message.origin, message.data.api, message.removeListener, [dispatcher]);
+                }
             }
         }
         for (const callbackRecord of this.pendingCallbacks.values()) {
@@ -675,9 +677,6 @@ export class Communication {
             }
         } else {
             if (methodConfig?.listener) {
-                if (!methodConfig.removeListener) {
-                    throw new Error(`removeListener is required for listener method ${method} of ${api}`);
-                }
                 const handlersBucket = this.handlers.get(this.getHandlerId(envId, api, method));
 
                 if (handlersBucket && handlersBucket.size !== 0) {

--- a/packages/core/src/com/message-types.ts
+++ b/packages/core/src/com/message-types.ts
@@ -30,6 +30,7 @@ export interface ListenMessage extends BaseMessage {
     type: 'listen';
     data: RemoteCallAddress;
     handlerId: string;
+    removeListener: string;
 }
 
 export interface UnListenMessage extends BaseMessage {

--- a/packages/core/src/com/message-types.ts
+++ b/packages/core/src/com/message-types.ts
@@ -30,7 +30,7 @@ export interface ListenMessage extends BaseMessage {
     type: 'listen';
     data: RemoteCallAddress;
     handlerId: string;
-    removeListener: string;
+    removeListener?: string;
 }
 
 export interface UnListenMessage extends BaseMessage {

--- a/packages/runtime-node/test/node-com.unit.ts
+++ b/packages/runtime-node/test/node-com.unit.ts
@@ -126,6 +126,7 @@ describe('Socket communication', () => {
             {
                 sub: {
                     listener: true,
+                    removeListener: 'unsub',
                 },
                 unsub: {
                     removeListener: 'sub',


### PR DESCRIPTION
This PR fixes recoonect issue with event dispatchers when environmant was removed we did not clean the listeners on the servies.

I added removeListener key requirement for the service config for now. let's make sure we all use `declareComEmitter`