### PR TITLE
fix(runtime node): node env manager to not broadcast node messages to web envs and allow communication between node envs

### DIFF
--- a/packages/core/src/com/hosts/base-host.ts
+++ b/packages/core/src/com/hosts/base-host.ts
@@ -19,7 +19,11 @@ export class BaseHost implements Target {
         }
     }
 
-    public removeEventListener(name: 'message', handler: (e: { data: Message }) => void, _capture?: boolean) {
+    public removeEventListener(
+        name: 'message',
+        handler: (e: { data: Message; source: Target }) => void,
+        _capture?: boolean,
+    ) {
         const handlers = this.handlers.get(name);
         if (handlers) {
             handlers.delete(handler);

--- a/packages/runtime-node/src/node-env-manager.ts
+++ b/packages/runtime-node/src/node-env-manager.ts
@@ -6,7 +6,6 @@ import {
     Message,
     MultiCounter,
     parseInjectRuntimeConfigConfig,
-    Target,
     UniversalWorkerHost,
 } from '@wixc3/engine-core';
 import { IDisposable, SetMultiMap } from '@wixc3/patterns';

--- a/packages/runtime-node/test-kit/entrypoints/a.node.ts
+++ b/packages/runtime-node/test-kit/entrypoints/a.node.ts
@@ -1,0 +1,62 @@
+import { bindMetricsListener, bindRpcListener, ParentPortHost } from '@wixc3/engine-runtime-node';
+import { workerData } from 'node:worker_threads';
+import { COM, FeatureClass, RuntimeEngine, TopLevelConfig } from '@wixc3/engine-core';
+import TestFeature from '../feature/test-feature.js';
+import { aEnv } from '../feature/envs.js';
+import '../feature/test-feature.a.env.js';
+
+const options = workerData?.runtimeOptions as Map<string, string> | undefined;
+const verbose = options?.get('verbose') ?? false;
+const env = aEnv;
+
+if (verbose) {
+    console.log(`[${env.env}: Started with options: `, options);
+}
+
+export function runEnv({
+    Feature = TestFeature,
+    topLevelConfig = [],
+}: { Feature?: FeatureClass; topLevelConfig?: TopLevelConfig } = {}) {
+    return new RuntimeEngine(
+        env,
+        [
+            ...(workerData
+                ? [
+                      COM.configure({
+                          config: {
+                              host: new ParentPortHost(env.env),
+                              id: env.env,
+                          },
+                      }),
+                  ]
+                : []),
+            ...topLevelConfig,
+        ],
+        new Map(options?.entries() ?? []),
+    ).run(Feature);
+}
+
+if (workerData) {
+    const unbindMetricsListener = bindMetricsListener();
+    const unbindTerminationListener = bindRpcListener('terminate', async () => {
+        if (verbose) {
+            console.log(`[${env.env}]: Termination Requested. Waiting for engine.`);
+        }
+        unbindTerminationListener();
+        unbindMetricsListener();
+        try {
+            const engine = await running;
+            if (verbose) {
+                console.log(`[${env.env}]: Terminating`);
+            }
+            return engine.shutdown();
+        } catch (e) {
+            console.error('[${env.name}]: Error while shutting down', e);
+            return;
+        }
+    });
+    // used by dispose to wait for engine to be ready
+    const running = runEnv();
+} else {
+    console.log('running engine in test mode');
+}

--- a/packages/runtime-node/test-kit/entrypoints/b.node.ts
+++ b/packages/runtime-node/test-kit/entrypoints/b.node.ts
@@ -1,0 +1,62 @@
+import { bindMetricsListener, bindRpcListener, ParentPortHost } from '@wixc3/engine-runtime-node';
+import { workerData } from 'node:worker_threads';
+import { COM, FeatureClass, RuntimeEngine, TopLevelConfig } from '@wixc3/engine-core';
+import TestFeature from '../feature/test-feature.js';
+import { bEnv } from '../feature/envs.js';
+import '../feature/test-feature.b.env.js';
+
+const options = workerData?.runtimeOptions as Map<string, string> | undefined;
+const verbose = options?.get('verbose') ?? false;
+const env = bEnv;
+
+if (verbose) {
+    console.log(`[${env.env}: Started with options: `, options);
+}
+
+export function runEnv({
+    Feature = TestFeature,
+    topLevelConfig = [],
+}: { Feature?: FeatureClass; topLevelConfig?: TopLevelConfig } = {}) {
+    return new RuntimeEngine(
+        env,
+        [
+            ...(workerData
+                ? [
+                      COM.configure({
+                          config: {
+                              host: new ParentPortHost(env.env),
+                              id: env.env,
+                          },
+                      }),
+                  ]
+                : []),
+            ...topLevelConfig,
+        ],
+        new Map(options?.entries() ?? []),
+    ).run(Feature);
+}
+
+if (workerData) {
+    const unbindMetricsListener = bindMetricsListener();
+    const unbindTerminationListener = bindRpcListener('terminate', async () => {
+        if (verbose) {
+            console.log(`[${env.env}]: Termination Requested. Waiting for engine.`);
+        }
+        unbindTerminationListener();
+        unbindMetricsListener();
+        try {
+            const engine = await running;
+            if (verbose) {
+                console.log(`[${env.env}]: Terminating`);
+            }
+            return engine.shutdown();
+        } catch (e) {
+            console.error('[${env.name}]: Error while shutting down', e);
+            return;
+        }
+    });
+    // used by dispose to wait for engine to be ready
+    const running = runEnv();
+} else {
+    console.log('running engine in test mode');
+}

--- a/packages/runtime-node/test-kit/feature/envs.ts
+++ b/packages/runtime-node/test-kit/feature/envs.ts
@@ -1,0 +1,4 @@
+import { Environment } from '@wixc3/engine-core';
+
+export const aEnv = new Environment('a', 'node', 'single');
+export const bEnv = new Environment('b', 'node', 'single');

--- a/packages/runtime-node/test-kit/feature/test-feature.a.env.ts
+++ b/packages/runtime-node/test-kit/feature/test-feature.a.env.ts
@@ -1,0 +1,13 @@
+import { aEnv } from './envs.js';
+import TestFeature from './test-feature.js';
+
+TestFeature.setup(aEnv, ({ echoBService }) => {
+    return {
+        echoAService: {
+            echo: () => 'a',
+            echoChained: async () => {
+                return echoBService.echo();
+            },
+        },
+    };
+});

--- a/packages/runtime-node/test-kit/feature/test-feature.b.env.ts
+++ b/packages/runtime-node/test-kit/feature/test-feature.b.env.ts
@@ -1,0 +1,13 @@
+import { bEnv } from './envs.js';
+import TestFeature from './test-feature.js';
+
+TestFeature.setup(bEnv, ({ echoAService }) => {
+    return {
+        echoBService: {
+            echo: () => 'b',
+            echoChained: async () => {
+                return echoAService.echo();
+            },
+        },
+    };
+});

--- a/packages/runtime-node/test-kit/feature/test-feature.ts
+++ b/packages/runtime-node/test-kit/feature/test-feature.ts
@@ -1,0 +1,12 @@
+import { COM, Feature, Service } from '@wixc3/engine-core';
+import { aEnv, bEnv } from './envs.js';
+import { EchoService } from './types.js';
+
+export default class TestFeature extends Feature<'test-feature'> {
+    id = 'test-feature' as const;
+    dependencies = [COM];
+    api = {
+        echoAService: Service.withType<EchoService>().defineEntity(aEnv).allowRemoteAccess(),
+        echoBService: Service.withType<EchoService>().defineEntity(bEnv).allowRemoteAccess(),
+    };
+}

--- a/packages/runtime-node/test-kit/feature/types.ts
+++ b/packages/runtime-node/test-kit/feature/types.ts
@@ -1,0 +1,4 @@
+export type EchoService = {
+    echo: () => string;
+    echoChained: () => Promise<string>;
+};

--- a/packages/runtime-node/test-kit/tsconfig.json
+++ b/packages/runtime-node/test-kit/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.test.json",
+  "compilerOptions": {
+    "outDir": "../dist/test-kit"
+  },
+  "references": [
+    {
+      "path": "../../core/src"
+    }
+  ]
+}

--- a/packages/runtime-node/test/node-env.manager.unit.ts
+++ b/packages/runtime-node/test/node-env.manager.unit.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { BaseHost, Communication, WsClientHost } from '@wixc3/engine-core';
+import { FeatureEnvironmentMapping, NodeEnvManager } from '@wixc3/engine-runtime-node';
+import { aEnv, bEnv } from '../test-kit/feature/envs.js';
+import { EchoService } from '../test-kit/feature/types.js';
+
+describe('NodeEnvManager with 2 node envs, remote api call', () => {
+    let manager: NodeEnvManager;
+    let communication: Communication;
+    beforeEach(async () => {
+        const featureEnvironmentsMapping: FeatureEnvironmentMapping = {
+            featureToEnvironments: {
+                'test-feature': [aEnv.env, bEnv.env],
+            },
+            availableEnvironments: {
+                a: {
+                    env: aEnv.env,
+                    endpointType: 'single',
+                    envType: 'node',
+                    dependencies: [],
+                },
+                b: {
+                    env: bEnv.env,
+                    endpointType: 'single',
+                    envType: 'node',
+                    dependencies: [],
+                },
+            },
+        };
+        const meta = { url: import.meta.resolve('../test-kit/entrypoints/') };
+
+        manager = new NodeEnvManager(meta, featureEnvironmentsMapping, {});
+        const com = new Communication(new BaseHost(), 'test');
+        const { port } = await manager.autoLaunch(new Map([['feature', 'test-feature']]));
+        const host = new WsClientHost('http://localhost:' + port, {});
+        com.registerEnv(aEnv.env, host);
+        com.registerEnv(bEnv.env, host);
+        com.registerMessageHandler(host);
+        communication = com;
+    });
+
+    afterEach(async () => {
+        await communication.dispose();
+        await manager.dispose();
+    });
+
+    it('should reach env "a"', async () => {
+        const api = communication.apiProxy<EchoService>({ id: aEnv.env }, { id: 'test-feature.echoAService' });
+
+        expect(await api.echo()).to.equal('a');
+    });
+    it('should reach env "a", env "a" should reach env "b"', async () => {
+        const api = communication.apiProxy<EchoService>({ id: aEnv.env }, { id: 'test-feature.echoAService' });
+
+        expect(await api.echoChained()).to.equal('b');
+    });
+    it('should reach env "b", env "b" should reach env "a"', async () => {
+        const api = communication.apiProxy<EchoService>({ id: bEnv.env }, { id: 'test-feature.echoBService' });
+
+        expect(await api.echoChained()).to.equal('a');
+    });
+});

--- a/packages/runtime-node/test/tsconfig.json
+++ b/packages/runtime-node/test/tsconfig.json
@@ -5,6 +5,7 @@
   },
   "references": [
     { "path": "../src" },
+    { "path": "../test-kit" },
     { "path": "../../test-kit/src" },
     { "path": "../../../test-fixtures/multi-node/src" },
     { "path": "../../../test-fixtures/multi-socket-node/src" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 
     { "path": "./packages/runtime-node/src" },
     { "path": "./packages/runtime-node/test" },
+    { "path": "./packages/runtime-node/test-kit" },
 
     { "path": "./packages/engine-cli/src" },
     { "path": "./packages/engine-cli/test" },


### PR DESCRIPTION
Problem: 
1) two node envs started by node env manager cannot communicate without without going through client
2) all worker messages being broadcasted to all registered ws clients

Example
![Screenshot 2025-03-04 at 16 30 53](https://github.com/user-attachments/assets/fd9afd75-66df-401f-a654-121632765c46)

Fix:
forward messages on worker parent level to desired worker directly via host communication which only purpose is to forward messages to a correct environment.

![image](https://github.com/user-attachments/assets/3b0c084d-f91a-4c3f-a719-088c37bf1485)


