### PR TITLE
feat: add support for custom pre-build configurations 

### DIFF
--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -17,7 +17,7 @@ import { createBuildConfiguration } from './create-environments-build-configurat
 import { readEntryPoints, writeEntryPoints } from './entrypoint-files.js';
 import { EntryPoints, EntryPointsPaths } from './create-entrypoints.js';
 import { resolveRuntimeOptions } from './resolve-runtime-options.js';
-import type { EngineConfig, PreBuildConfig } from './types.js';
+import type { EngineConfig } from './types.js';
 import { analyzeFeatures } from './find-features/analyze-features.js';
 import { ENGINE_CONFIG_FILE_NAME } from './find-features/build-constants.js';
 import { runPreBuilds } from './pre-build.js';
@@ -45,7 +45,7 @@ export interface RunEngineOptions {
     staticBuild?: boolean;
     customEntrypoints?: string;
     title?: string;
-    customPreBuildDist?: PreBuildConfig[];
+    customPreBuildDist?: string[];
 }
 
 export async function runEngine({

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -295,11 +295,11 @@ export async function runEngine({
     };
 }
 
-function shouldBuildWeb(buildTargets: 'node' | 'web' | 'both' | 'electron') {
+export function shouldBuildWeb(buildTargets: 'node' | 'web' | 'both' | 'electron') {
     return buildTargets === 'web' || buildTargets === 'both' || buildTargets === 'electron';
 }
 
-function shouldBuildNode(buildTargets: 'node' | 'web' | 'both' | 'electron') {
+export function shouldBuildNode(buildTargets: 'node' | 'web' | 'both' | 'electron') {
     return buildTargets === 'node' || buildTargets === 'both' || buildTargets === 'electron';
 }
 

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -20,6 +20,7 @@ import { resolveRuntimeOptions } from './resolve-runtime-options.js';
 import type { EngineConfig } from './types.js';
 import { analyzeFeatures } from './find-features/analyze-features.js';
 import { ENGINE_CONFIG_FILE_NAME } from './find-features/build-constants.js';
+import { PreBuildConfig, runPreBuilds } from './pre-build.js';
 
 export interface RunEngineOptions {
     verbose?: boolean;
@@ -44,6 +45,7 @@ export interface RunEngineOptions {
     staticBuild?: boolean;
     customEntrypoints?: string;
     title?: string;
+    customPreBuildDist?: PreBuildConfig[];
 }
 
 export async function runEngine({
@@ -69,6 +71,7 @@ export async function runEngine({
     staticBuild = false,
     customEntrypoints = engineConfig.customEntrypoints,
     title,
+    customPreBuildDist = engineConfig.customPreBuildDist,
 }: RunEngineOptions = {}): Promise<{
     featureEnvironmentsMapping: FeatureEnvironmentMapping;
     configMapping: ConfigurationEnvironmentMapping;
@@ -197,6 +200,10 @@ export async function runEngine({
         title,
         favicon,
     });
+
+    if (customPreBuildDist) {
+        await runPreBuilds(rootDir, outputPath, customPreBuildDist, dev, buildConfigurations, buildTargets, true);
+    }
 
     if (watch) {
         if (shouldBuildWeb(buildTargets)) {

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -202,7 +202,7 @@ export async function runEngine({
     });
 
     if (customPreBuildDist) {
-        await runPreBuilds(rootDir, outputPath, customPreBuildDist, dev, buildConfigurations, buildTargets, verbose);
+        await runPreBuilds(rootDir, customPreBuildDist, buildConfigurations, buildTargets, verbose);
     }
 
     if (watch) {

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -17,10 +17,10 @@ import { createBuildConfiguration } from './create-environments-build-configurat
 import { readEntryPoints, writeEntryPoints } from './entrypoint-files.js';
 import { EntryPoints, EntryPointsPaths } from './create-entrypoints.js';
 import { resolveRuntimeOptions } from './resolve-runtime-options.js';
-import type { EngineConfig } from './types.js';
+import type { EngineConfig, PreBuildConfig } from './types.js';
 import { analyzeFeatures } from './find-features/analyze-features.js';
 import { ENGINE_CONFIG_FILE_NAME } from './find-features/build-constants.js';
-import { PreBuildConfig, runPreBuilds } from './pre-build.js';
+import { runPreBuilds } from './pre-build.js';
 
 export interface RunEngineOptions {
     verbose?: boolean;
@@ -202,7 +202,7 @@ export async function runEngine({
     });
 
     if (customPreBuildDist) {
-        await runPreBuilds(rootDir, outputPath, customPreBuildDist, dev, buildConfigurations, buildTargets, true);
+        await runPreBuilds(rootDir, outputPath, customPreBuildDist, dev, buildConfigurations, buildTargets, verbose);
     }
 
     if (watch) {

--- a/packages/engine-cli/src/engine-build.ts
+++ b/packages/engine-cli/src/engine-build.ts
@@ -206,6 +206,9 @@ export async function runEngine({
     }
 
     if (watch) {
+        if (watch && customPreBuildDist) {
+            console.log('Notice that pre-builds does not support watch mode');
+        }
         if (shouldBuildWeb(buildTargets)) {
             if (verbose) {
                 console.log('Starting web compilation in watch mode');

--- a/packages/engine-cli/src/index.ts
+++ b/packages/engine-cli/src/index.ts
@@ -13,3 +13,4 @@ export { runLocalNodeManager } from './run-local-mode-manager.js';
 export * from './types.js';
 export type { IExecutableApplication, RunningFeature } from './types.js';
 export { checkWatchSignal } from './watch-signal.js';
+export { runPreBuilds } from './pre-build.js';

--- a/packages/engine-cli/src/pre-build.ts
+++ b/packages/engine-cli/src/pre-build.ts
@@ -1,0 +1,64 @@
+import esbuild from 'esbuild';
+import path from 'node:path';
+import { BuildConfiguration } from './types.js';
+
+export interface PreBuildConfig {
+    distName: string;
+    paths: string[];
+}
+
+export async function runPreBuilds(
+    rootDir: string,
+    outputPath: string,
+    preBuilds: PreBuildConfig[],
+    dev: boolean,
+    buildConfiguration: BuildConfiguration,
+    buildTargets: 'node' | 'web' | 'both' | 'electron',
+    verbose = false,
+): Promise<void> {
+    if (!preBuilds.length) {
+        return;
+    }
+
+    if (verbose) {
+        console.log(`Running ${preBuilds.length} pre-builds before main build...`);
+    }
+
+    for (const preBuild of preBuilds) {
+        const { distName, paths } = preBuild;
+        if (!paths.length) {
+            continue;
+        }
+
+        const outputDir = path.join(outputPath, distName);
+
+        if (verbose) {
+            console.log(`Building ${paths.length} files to ${outputDir}`);
+        }
+
+        // Resolve entry points relative to rootDir
+        const entryPoints = paths.map((entryPath) => path.resolve(rootDir, entryPath));
+
+        await esbuild.build({
+            entryPoints,
+            outdir: outputDir,
+            bundle: true,
+            format: 'iife',
+            target: 'es2022',
+            minify: !dev,
+            sourcemap: dev,
+            logLevel: verbose ? 'info' : 'warning',
+            color: true,
+            legalComments: 'none',
+            loader: {
+                '.ttf': 'file',
+                '.woff': 'file',
+                '.woff2': 'file',
+            },
+        });
+
+        if (verbose) {
+            console.log(`Pre-build "${distName}" completed successfully`);
+        }
+    }
+}

--- a/packages/engine-cli/src/pre-build.ts
+++ b/packages/engine-cli/src/pre-build.ts
@@ -26,31 +26,33 @@ export async function runPreBuilds(
             continue;
         }
 
-        const outputDir = path.join(outputPath, distName);
-
-        if (verbose) {
-            console.log(`Building ${paths.length} files to ${outputDir}`);
-        }
-
         const entryPoints = paths.map((entryPath) => path.resolve(rootDir, entryPath));
 
         if (shouldBuildNode(buildTargets)) {
+            const outputDir = path.join(buildConfiguration.nodeConfig.outdir || '', distName);
+            if (verbose) {
+                console.log(`Building ${paths.length} files to ${outputDir}`);
+            }
             const { plugins: _plugins, ...configWithoutPlugins } = buildConfiguration.nodeConfig;
             const baseConfig: esbuild.BuildOptions = {
                 entryPoints,
-                outdir: outputDir,
                 ...configWithoutPlugins,
+                outdir: outputDir,
             };
 
             await esbuild.build(baseConfig);
         }
 
         if (shouldBuildWeb(buildTargets)) {
+            const outputDir = path.join(buildConfiguration.webConfig.outdir || '', distName);
+            if (verbose) {
+                console.log(`Building ${paths.length} files to ${outputDir}`);
+            }
             const { plugins: _plugins, ...configWithoutPlugins } = buildConfiguration.webConfig;
             const baseConfig: esbuild.BuildOptions = {
                 entryPoints,
-                outdir: outputDir,
                 ...configWithoutPlugins,
+                outdir: outputDir,
             };
 
             await esbuild.build(baseConfig);

--- a/packages/engine-cli/src/pre-build.ts
+++ b/packages/engine-cli/src/pre-build.ts
@@ -1,65 +1,54 @@
 import esbuild from 'esbuild';
 import path from 'node:path';
-import { BuildConfiguration, PreBuildConfig } from './types.js';
+import { BuildConfiguration } from './types.js';
 import { shouldBuildNode, shouldBuildWeb } from './engine-build.js';
 
 export async function runPreBuilds(
     rootDir: string,
     outputPath: string,
-    preBuilds: PreBuildConfig[],
+    preBuildsPaths: string[],
     dev: boolean,
     buildConfiguration: BuildConfiguration,
     buildTargets: 'node' | 'web' | 'both' | 'electron',
     verbose = false,
 ): Promise<void> {
-    if (!preBuilds.length) {
+    if (!preBuildsPaths.length) {
         return;
     }
 
     if (verbose) {
-        console.log(`Running ${preBuilds.length} pre-builds before main build...`);
+        console.log(`Running ${preBuildsPaths.length} pre-builds before main build...`);
     }
 
-    for (const preBuild of preBuilds) {
-        const { distName, paths } = preBuild;
-        if (!paths.length) {
-            continue;
-        }
+    const entryPoints = preBuildsPaths.map((entryPath) => path.resolve(rootDir, entryPath));
 
-        const entryPoints = paths.map((entryPath) => path.resolve(rootDir, entryPath));
-
-        if (shouldBuildNode(buildTargets)) {
-            const outputDir = path.join(buildConfiguration.nodeConfig.outdir || '', distName);
-            if (verbose) {
-                console.log(`Building ${paths.length} files to ${outputDir}`);
-            }
-            const { plugins: _plugins, ...configWithoutPlugins } = buildConfiguration.nodeConfig;
-            const baseConfig: esbuild.BuildOptions = {
-                entryPoints,
-                ...configWithoutPlugins,
-                outdir: outputDir,
-            };
-
-            await esbuild.build(baseConfig);
-        }
-
-        if (shouldBuildWeb(buildTargets)) {
-            const outputDir = path.join(buildConfiguration.webConfig.outdir || '', distName);
-            if (verbose) {
-                console.log(`Building ${paths.length} files to ${outputDir}`);
-            }
-            const { plugins: _plugins, ...configWithoutPlugins } = buildConfiguration.webConfig;
-            const baseConfig: esbuild.BuildOptions = {
-                entryPoints,
-                ...configWithoutPlugins,
-                outdir: outputDir,
-            };
-
-            await esbuild.build(baseConfig);
-        }
-
+    if (shouldBuildNode(buildTargets)) {
         if (verbose) {
-            console.log(`Pre-build "${distName}" completed successfully`);
+            console.log(`Building ${preBuildsPaths.length} files to ${buildConfiguration.webConfig.outdir}`);
         }
+        const { plugins: _plugins, ...configWithoutPlugins } = buildConfiguration.nodeConfig;
+        const baseConfig: esbuild.BuildOptions = {
+            entryPoints,
+            ...configWithoutPlugins,
+        };
+
+        await esbuild.build(baseConfig);
+    }
+
+    if (shouldBuildWeb(buildTargets)) {
+        if (verbose) {
+            console.log(`Building ${preBuildsPaths.length} files to ${buildConfiguration.webConfig.outdir}`);
+        }
+        const { plugins: _plugins, ...configWithoutPlugins } = buildConfiguration.webConfig;
+        const baseConfig: esbuild.BuildOptions = {
+            entryPoints,
+            ...configWithoutPlugins,
+        };
+
+        await esbuild.build(baseConfig);
+    }
+
+    if (verbose) {
+        console.log(`Pre-build completed successfully`);
     }
 }

--- a/packages/engine-cli/src/pre-build.ts
+++ b/packages/engine-cli/src/pre-build.ts
@@ -5,9 +5,7 @@ import { shouldBuildNode, shouldBuildWeb } from './engine-build.js';
 
 export async function runPreBuilds(
     rootDir: string,
-    outputPath: string,
     preBuildsPaths: string[],
-    dev: boolean,
     buildConfiguration: BuildConfiguration,
     buildTargets: 'node' | 'web' | 'both' | 'electron',
     verbose = false,

--- a/packages/engine-cli/src/pre-build.ts
+++ b/packages/engine-cli/src/pre-build.ts
@@ -14,9 +14,7 @@ export async function runPreBuilds(
         return;
     }
 
-    if (verbose) {
-        console.log(`Running ${preBuildsPaths.length} pre-builds before main build...`);
-    }
+    console.log(`Running ${preBuildsPaths.length} pre-builds before main build...`);
 
     const entryPoints = preBuildsPaths.map((entryPath) => path.resolve(rootDir, entryPath));
 

--- a/packages/engine-cli/src/pre-build.ts
+++ b/packages/engine-cli/src/pre-build.ts
@@ -1,11 +1,6 @@
 import esbuild from 'esbuild';
 import path from 'node:path';
-import { BuildConfiguration } from './types.js';
-
-export interface PreBuildConfig {
-    distName: string;
-    paths: string[];
-}
+import { BuildConfiguration, PreBuildConfig } from './types.js';
 
 export async function runPreBuilds(
     rootDir: string,

--- a/packages/engine-cli/src/types.ts
+++ b/packages/engine-cli/src/types.ts
@@ -8,7 +8,6 @@ import type {
 } from '@wixc3/engine-runtime-node';
 import type { BuildOptions } from 'esbuild';
 import type io from 'socket.io';
-import { PreBuildConfig } from './pre-build.js';
 
 export interface IFeatureTarget {
     featureName?: string;
@@ -117,4 +116,9 @@ export interface IFeatureModule {
      * it will be set as `'processing': 'webworker'`
      */
     usedContexts?: Record<string, string>;
+}
+
+export interface PreBuildConfig {
+    distName: string;
+    paths: string[];
 }

--- a/packages/engine-cli/src/types.ts
+++ b/packages/engine-cli/src/types.ts
@@ -8,6 +8,7 @@ import type {
 } from '@wixc3/engine-runtime-node';
 import type { BuildOptions } from 'esbuild';
 import type io from 'socket.io';
+import { PreBuildConfig } from './pre-build.js';
 
 export interface IFeatureTarget {
     featureName?: string;
@@ -58,6 +59,7 @@ export interface EngineConfig {
     /** @default [".js", ".json"] */
     extensions?: string[];
     engineRuntimeArgsFlags?: Record<string, CliFlag<string | boolean>>;
+    customPreBuildDist?: PreBuildConfig[];
 }
 
 export interface StaticConfig {

--- a/packages/engine-cli/src/types.ts
+++ b/packages/engine-cli/src/types.ts
@@ -58,7 +58,7 @@ export interface EngineConfig {
     /** @default [".js", ".json"] */
     extensions?: string[];
     engineRuntimeArgsFlags?: Record<string, CliFlag<string | boolean>>;
-    customPreBuildDist?: PreBuildConfig[];
+    customPreBuildDist?: string[];
 }
 
 export interface StaticConfig {
@@ -116,9 +116,4 @@ export interface IFeatureModule {
      * it will be set as `'processing': 'webworker'`
      */
     usedContexts?: Record<string, string>;
-}
-
-export interface PreBuildConfig {
-    distName: string;
-    paths: string[];
 }

--- a/packages/engine-cli/test/pre-build.unit.ts
+++ b/packages/engine-cli/test/pre-build.unit.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+import { runPreBuilds } from '@wixc3/engine-cli';
+import { writeFileSync, existsSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { cwd } from 'node:process';
+
+const createdFiles: string[] = [];
+
+function writeTestFile(filePath: string, content: string): void {
+    writeFileSync(filePath, content);
+    createdFiles.push(filePath);
+}
+
+const mockSrcDir = path.join(cwd(), 'mock-src');
+const outputDir = path.join(cwd(), 'output');
+
+describe('runPreBuilds', () => {
+    beforeEach(() => {
+        mkdirSync(mockSrcDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        createdFiles.forEach((file) => {
+            if (existsSync(file)) {
+                unlinkSync(file);
+            }
+        });
+        createdFiles.length = 0;
+        if (existsSync(outputDir)) {
+            rmSync(outputDir, { recursive: true });
+        }
+        if (existsSync(mockSrcDir)) {
+            rmSync(mockSrcDir, { recursive: true });
+        }
+    });
+
+    it('should build for node and web to specific directory', async () => {
+        const filePath = path.join(mockSrcDir, 'file.js');
+        writeTestFile(filePath, '');
+
+        await runPreBuilds(
+            mockSrcDir,
+            path.join(cwd(), 'output'),
+            [
+                {
+                    distName: 'not-empty',
+                    paths: [filePath],
+                },
+            ],
+            false,
+            {
+                nodeConfig: { outdir: 'output/node' } as any,
+                webConfig: { outdir: 'output/web' } as any,
+            },
+            'both',
+            true,
+        );
+
+        expect(existsSync(path.join(outputDir, 'node'))).to.be.true;
+        expect(existsSync(path.join(outputDir, 'web'))).to.be.true;
+    });
+
+    it('should not build if the paths are empty', async () => {
+        await runPreBuilds(
+            mockSrcDir,
+            path.join(cwd(), 'output'),
+            [
+                {
+                    distName: 'empty',
+                    paths: [],
+                },
+            ],
+            false,
+            {
+                nodeConfig: { outdir: 'output/node' } as any,
+                webConfig: { outdir: 'output/web' } as any,
+            },
+            'both',
+            true,
+        );
+
+        expect(existsSync(path.join(outputDir, 'node'))).to.be.false;
+        expect(existsSync(path.join(outputDir, 'web'))).to.be.false;
+    });
+});

--- a/packages/engine-cli/test/pre-build.unit.ts
+++ b/packages/engine-cli/test/pre-build.unit.ts
@@ -41,19 +41,14 @@ describe('runPreBuilds', () => {
         await runPreBuilds(
             mockSrcDir,
             path.join(cwd(), 'output'),
-            [
-                {
-                    distName: 'not-empty',
-                    paths: [filePath],
-                },
-            ],
+            [filePath],
             false,
             {
                 nodeConfig: { outdir: 'output/node' } as any,
                 webConfig: { outdir: 'output/web' } as any,
             },
             'both',
-            true,
+            false,
         );
 
         expect(existsSync(path.join(outputDir, 'node'))).to.be.true;
@@ -64,12 +59,7 @@ describe('runPreBuilds', () => {
         await runPreBuilds(
             mockSrcDir,
             path.join(cwd(), 'output'),
-            [
-                {
-                    distName: 'empty',
-                    paths: [],
-                },
-            ],
+            [],
             false,
             {
                 nodeConfig: { outdir: 'output/node' } as any,

--- a/packages/engine-cli/test/pre-build.unit.ts
+++ b/packages/engine-cli/test/pre-build.unit.ts
@@ -40,9 +40,7 @@ describe('runPreBuilds', () => {
 
         await runPreBuilds(
             mockSrcDir,
-            path.join(cwd(), 'output'),
             [filePath],
-            false,
             {
                 nodeConfig: { outdir: 'output/node' } as any,
                 webConfig: { outdir: 'output/web' } as any,
@@ -58,9 +56,7 @@ describe('runPreBuilds', () => {
     it('should not build if the paths are empty', async () => {
         await runPreBuilds(
             mockSrcDir,
-            path.join(cwd(), 'output'),
             [],
-            false,
             {
                 nodeConfig: { outdir: 'output/node' } as any,
                 webConfig: { outdir: 'output/web' } as any,


### PR DESCRIPTION
Add the option to pass to the engine config an array of paths which should be bundled before the main bundle.

example of usage:
```ts
customPreBuildDist: [
        './src/code-editor/vendors/monaco-css-worker.ts',
        './src/code-editor/vendors/monaco-generic-worker.ts',
        './src/code-editor/vendors/monaco-html-worker.ts',
        './src/code-editor/vendors/monaco-json-worker.ts',
    ],
```