### PR TITLE
feat: deprecated reportError as an anti-pattern

### DIFF
--- a/packages/core/src/com/logs.ts
+++ b/packages/core/src/com/logs.ts
@@ -31,6 +31,7 @@ export const REGISTER_ENV = (id: string, hostId: string) => `registering env ${i
 export const UNHANDLED = (message: Message, hostId: string) =>
     `[DEBUG] unhandledMessage received at ${hostId}. message:\n${JSON.stringify(message, null, 2)}`;
 
+/** @deprecated This function is an anti-pattern, and was used by everyone to bypass the no-console lint rule; avoid using it! *Handle failures* rather than only printing them to the console. */
 export function reportError(e: unknown) {
     console.error(e);
 }


### PR DESCRIPTION
We've had this escape hatch for far too long