### PR TITLE
feat: handle env reconnect

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -65,6 +65,7 @@ export interface CommunicationOptions {
     warnOnSlow?: boolean;
     publicPath?: string;
     connectedEnvironments?: { [environmentId: string]: ConfigEnvironmentRecord };
+    apis?: RemoteAPIServicesMapping;
 }
 
 /**
@@ -82,7 +83,7 @@ export class Communication {
     private pendingMessages = new SetMultiMap<string, UnknownFunction>();
     private handlers = new Map<string, { message: ListenMessage; callbacks: Set<UnknownFunction> }>();
     private eventDispatchers = new Map<string, { dispatcher: SerializableMethod; message: ListenMessage }>();
-    private apis: RemoteAPIServicesMapping = {};
+    private apis: RemoteAPIServicesMapping;
     private apisOverrides: RemoteAPIServicesMapping = {};
     private options: Required<CommunicationOptions>;
     private readyEnvs = new Set<string>();
@@ -106,6 +107,7 @@ export class Communication {
             warnOnSlow: this.DEBUG,
             publicPath: '',
             connectedEnvironments: {},
+            apis: {},
             ...options,
         };
         this.rootEnvId = id;
@@ -114,7 +116,7 @@ export class Communication {
         this.registerEnv(id, host);
         this.environments['*'] = { id, host };
         this.messageIdPrefix = `c_${this.rootEnvId}_${Math.random().toString(36).slice(2)}`;
-
+        this.apis = this.options.apis;
         for (const [id, envEntry] of Object.entries(this.options.connectedEnvironments)) {
             if (envEntry.registerMessageHandler) {
                 this.registerMessageHandler(envEntry.host);

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -80,7 +80,7 @@ export class Communication {
     private readonly slowThreshold = 5_000; // 5 seconds
     private pendingEnvs: SetMultiMap<string, () => void> = new SetMultiMap();
     private pendingMessages = new SetMultiMap<string, UnknownFunction>();
-    private handlers = new Map<string, Set<UnknownFunction>>();
+    private handlers = new Map<string, { message: ListenMessage; callbacks: Set<UnknownFunction> }>();
     private eventDispatchers = new Map<string, { dispatcher: SerializableMethod; message: ListenMessage }>();
     private apis: RemoteAPIServicesMapping = {};
     private apisOverrides: RemoteAPIServicesMapping = {};
@@ -407,8 +407,8 @@ export class Communication {
             rootEnvId: this.rootEnvId,
             pendingEnvs: countValues(this.pendingEnvs),
             pendingMessages: countValues(this.pendingMessages),
-            handlers: Array.from(this.handlers).reduce<Record<string, number>>((acc, [key, value]) => {
-                acc[key] = value.size;
+            handlers: Array.from(this.handlers).reduce<Record<string, number>>((acc, [key, { callbacks }]) => {
+                acc[key] = callbacks.size;
                 return acc;
             }, {}),
             eventDispatchers: Array.from(this.eventDispatchers.keys()),
@@ -579,14 +579,7 @@ export class Communication {
         this.pendingMessages.deleteKey(instanceId);
         this.pendingEnvs.deleteKey(instanceId);
         delete this.environments[instanceId];
-        for (const [dispatcherKey, { message, dispatcher }] of this.eventDispatchers) {
-            if (dispatcherKey.endsWith(instanceId)) {
-                this.eventDispatchers.delete(dispatcherKey);
-                if (message.removeListener) {
-                    this.apiCall(message.origin, message.data.api, message.removeListener, [dispatcher]);
-                }
-            }
-        }
+        this.clearEventDispatchersByEnvId(instanceId);
         for (const callbackRecord of this.pendingCallbacks.values()) {
             if (callbackRecord.message.to === instanceId) {
                 callbackRecord.reject(
@@ -596,6 +589,17 @@ export class Communication {
         }
         for (const dispose of this.disposeListeners) {
             dispose(instanceId);
+        }
+    }
+
+    private clearEventDispatchersByEnvId(instanceId: string) {
+        for (const [dispatcherKey, { message, dispatcher }] of this.eventDispatchers) {
+            if (dispatcherKey.endsWith(instanceId)) {
+                this.eventDispatchers.delete(dispatcherKey);
+                if (message.removeListener) {
+                    this.apiCall(message.origin, message.data.api, message.removeListener, [dispatcher]);
+                }
+            }
         }
     }
 
@@ -660,11 +664,11 @@ export class Communication {
                 return;
             }
             if (methodConfig?.removeListener) {
-                listenerHandlersBucket.delete(fn);
+                listenerHandlersBucket.callbacks.delete(fn);
             } else {
-                listenerHandlersBucket.clear();
+                listenerHandlersBucket.callbacks.clear();
             }
-            if (listenerHandlersBucket.size === 0) {
+            if (listenerHandlersBucket.callbacks.size === 0) {
                 // send remove handler call
                 const message: UnListenMessage = {
                     to: envId,
@@ -687,12 +691,12 @@ export class Communication {
             if (methodConfig?.listener) {
                 const handlersBucket = this.handlers.get(this.getHandlerId(envId, api, method));
 
-                if (handlersBucket && handlersBucket.size !== 0) {
-                    if (handlersBucket.has(fn)) {
+                if (handlersBucket && handlersBucket.callbacks.size !== 0) {
+                    if (handlersBucket.callbacks.has(fn)) {
                         const handlerId = this.getHandlerId(envId, api, method);
                         throw new DuplicateRegistrationError(handlerId, 'Listener');
                     }
-                    handlersBucket.add(fn);
+                    handlersBucket.callbacks.add(fn);
                     res();
                 } else {
                     const message: ListenMessage = {
@@ -704,10 +708,11 @@ export class Communication {
                             method,
                         },
                         removeListener: methodConfig.removeListener,
-                        handlerId: this.createHandlerRecord(envId, api, method, fn),
+                        handlerId: '',
                         callbackId,
                         origin,
                     };
+                    message.handlerId = this.createHandlerRecord(envId, api, method, fn, message);
 
                     this.callWithCallback(envId, message, callbackId, res, rej);
                 }
@@ -774,7 +779,7 @@ export class Communication {
         if (!handlers) {
             return;
         }
-        for (const handler of handlers) {
+        for (const handler of handlers.callbacks) {
             handler(...message.data);
         }
     }
@@ -801,6 +806,16 @@ export class Communication {
                 cb();
             }
         } else if (wasEnvironmentAlreadyReady) {
+            // clear previous dispatchers
+            this.clearEventDispatchersByEnvId(from);
+            // re-register listeners
+            for (const { message } of this.handlers.values()) {
+                // run over listeners that were connected to the previous env
+                if (message.to === from) {
+                    // resend listener registration
+                    this.sendTo(message.to, { ...message, callbackId: undefined });
+                }
+            }
             for (const reConnectHandler of this.reConnectListeners) {
                 reConnectHandler(from);
             }
@@ -934,7 +949,13 @@ export class Communication {
     private getHandlerId(envId: string, api: string, method: string) {
         return `${this.createHandlerIdPrefix({ from: this.rootEnvId, to: envId })}${api}@${method}`;
     }
-    private createHandlerRecord(envId: string, api: string, method: string, fn: UnknownFunction): string {
+    private createHandlerRecord(
+        envId: string,
+        api: string,
+        method: string,
+        fn: UnknownFunction,
+        message: ListenMessage,
+    ): string {
         const handlerId = this.getHandlerId(envId, api, method);
         const handlersBucket = this.handlers.get(handlerId);
         if (!handlersBucket) {
@@ -944,7 +965,9 @@ export class Communication {
                 }
             });
         }
-        handlersBucket ? handlersBucket.add(fn) : this.handlers.set(handlerId, new Set([fn]));
+        handlersBucket
+            ? handlersBucket.callbacks.add(fn)
+            : this.handlers.set(handlerId, { message, callbacks: new Set([fn]) });
         return handlerId;
     }
     private createCallbackRecord(

--- a/packages/core/src/com/helpers.ts
+++ b/packages/core/src/com/helpers.ts
@@ -1,6 +1,7 @@
 // we cannot mix types of "dom" and "webworker". tsc fails building.
 declare let WorkerGlobalScope: new () => Worker;
 
+import { BaseHost } from './hosts/base-host.js';
 import { Message } from './message-types.js';
 
 export function isWorkerContext(target: unknown): target is Worker {
@@ -11,7 +12,7 @@ export function isWorkerContext(target: unknown): target is Worker {
 }
 
 export function isWindow(win: unknown): win is Window {
-    return typeof Window !== 'undefined' && win instanceof Window;
+    return typeof Window !== 'undefined' && win instanceof Window || (win instanceof BaseHost && win.parent !== undefined);
 }
 
 export function isIframe(iframe: unknown): iframe is HTMLIFrameElement {

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -605,6 +605,50 @@ describe('Communication', () => {
 
         expect(onEnvReconnect).to.have.have.callCount(1);
     });
+    it('should auto connect event listeners when env is re-connected', async () => {
+        const onEventReconnect = spy();
+        const onEventEmitterCall = spy();
+        const hostA = new BaseHost('A-host');
+        const hostB = hostA.open('B-host');
+        const comA = new Communication(hostA, 'A');
+        const comB_api1 = { service: getMockApi() };
+        const comB = new Communication(hostB, 'B', undefined, undefined, undefined, { apis: comB_api1 });
+        comA.registerEnv('B', hostB);
+        comB.registerEnv('A', hostA);
+        comA.subscribeToEnvironmentReconnect(onEventReconnect);
+
+        // setup api between comA and comB
+        const apiProxy = comA.apiProxy<typeof comB_api1.service>(
+            { id: 'B' },
+            { id: 'service' },
+            { listen: { listener: true, emitOnly: true } },
+        );
+
+        await apiProxy.listen(onEventEmitterCall);
+
+        comB_api1.service.invoke();
+
+        await waitFor(() => {
+            expect(onEventEmitterCall, 'invoked event before reconnect').to.have.have.callCount(1);
+        });
+
+        // simulate unavailable communication
+        comB.removeMessageHandler(hostB);
+        // reconnect
+        const comB_api2 = { service: getMockApi() };
+        new Communication(hostB, 'B', undefined, undefined, undefined, { apis: comB_api2 });
+
+        await waitFor(() => {
+            expect(onEventReconnect, 'reconnected').to.been.calledWith('B');
+            expect(comB_api2.service.getListenersCount(), 'event handler re-register').to.eq(1);
+        });
+
+        comB_api2.service.invoke();
+
+        await waitFor(() => {
+            expect(onEventEmitterCall, 'invoked event after reconnect').to.have.have.callCount(2);
+        });
+    });
 });
 
 describe('environment-dependencies communication', () => {

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -584,6 +584,27 @@ describe('Communication', () => {
 
         await expect(apiProxy.test()).to.be.rejected;
     });
+    it('should report env re connection', () => {
+        const onEnvReconnect = spy();
+        const hostA = new BaseHost();
+        const hostB = new BaseHost();
+        const comA = new Communication(hostA, 'A');
+        const comB = new Communication(hostB, 'B'); // ready is ignored since nothing is connected
+        comA.registerEnv('B', hostB);
+        comA.registerMessageHandler(hostB);
+        comB.registerEnv('A', hostA);
+        comB.registerMessageHandler(hostA);
+
+        comA.subscribeToEnvironmentReconnect(onEnvReconnect);
+
+        new Communication(hostB, 'B'); // first ready
+
+        expect(onEnvReconnect).to.have.have.callCount(0);
+
+        new Communication(hostB, 'B'); // re-connect
+
+        expect(onEnvReconnect).to.have.have.callCount(1);
+    });
 });
 
 describe('environment-dependencies communication', () => {


### PR DESCRIPTION
This PR adds handling for env reconnect:
- a `subscribeToEnvironmentReconnect` to allow getting events of env that is re-connected, for example when an iframe is reloaded.
- auto reconnect for event listeners