### PR TITLE
fix: handle reconnect with different host

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -134,12 +134,12 @@ export class Communication {
     /**
      * Registers environments that spawned in the same execution context as the root environment.
      */
-    public registerEnv(id: string, host: Target): void {
+    public registerEnv(id: string, host: Target, forceRegister: boolean = false): void {
         if (this.DEBUG) {
             console.debug(REGISTER_ENV(id, this.rootEnvId));
         }
         const existingEnv = this.environments[id];
-        if (!existingEnv) {
+        if (!existingEnv || forceRegister) {
             this.environments[id] = { id, host } as EnvironmentRecord;
         } else if (existingEnv.host !== host) {
             throw new DuplicateRegistrationError(id, 'Environment');
@@ -470,12 +470,13 @@ export class Communication {
         return true;
     }
     private autoRegisterEnvFromMessage(message: Message, source: Target) {
-        if (!this.environments[message.from]) {
+        const forceRegister = message.type === 'ready';
+        if (!this.environments[message.from] || forceRegister) {
             if (this.DEBUG) {
                 console.debug(MESSAGE_FROM_UNKNOWN_ENVIRONMENT(redactArguments(message), this.rootEnvId));
             }
             if (this.validateRegistration(source, message)) {
-                this.registerEnv(message.from, source);
+                this.registerEnv(message.from, source, forceRegister);
             }
         }
         if (!this.environments[message.origin]) {
@@ -483,7 +484,7 @@ export class Communication {
                 console.debug(MESSAGE_FROM_UNKNOWN_ENVIRONMENT(redactArguments(message), this.rootEnvId), 'origin');
             }
             if (this.validateRegistration(source, message)) {
-                this.registerEnv(message.origin, source);
+                this.registerEnv(message.origin, source, forceRegister);
             }
         }
     }

--- a/packages/core/test/node/com.spec.ts
+++ b/packages/core/test/node/com.spec.ts
@@ -649,6 +649,52 @@ describe('Communication', () => {
             expect(onEventEmitterCall, 'invoked event after reconnect').to.have.have.callCount(2);
         });
     });
+    it('should auto connect event listeners when env is re-connected (replaced host)', async () => {
+        const onEventReconnect = spy();
+        const onEventEmitterCall = spy();
+        const hostA = new BaseHost('A-host');
+        const hostB = hostA.open('B-host');
+        const comA = new Communication(hostA, 'A');
+        const comB_api1 = { service: getMockApi() };
+        const comB = new Communication(hostB, 'B', undefined, undefined, undefined, { apis: comB_api1 });
+        comA.registerEnv('B', hostB);
+        comB.registerEnv('A', hostA);
+        comA.subscribeToEnvironmentReconnect(onEventReconnect);
+
+        // setup api between comA and comB
+        const apiProxy = comA.apiProxy<typeof comB_api1.service>(
+            { id: 'B' },
+            { id: 'service' },
+            { listen: { listener: true, emitOnly: true } },
+        );
+
+        await apiProxy.listen(onEventEmitterCall);
+
+        comB_api1.service.invoke();
+
+        await waitFor(() => {
+            expect(onEventEmitterCall, 'invoked event before reconnect').to.have.have.callCount(1);
+        });
+
+        // simulate unavailable communication
+        comB.removeMessageHandler(hostB);
+        // reconnect - simulate another window
+        const hostB_2 = new BaseHost('B-host-2'); //hostA.open('B-host-2');
+        comA.registerMessageHandler(hostB_2);
+        const comB_api2 = { service: getMockApi() };
+        new Communication(hostB_2, 'B', undefined, undefined, undefined, { apis: comB_api2 });
+
+        await waitFor(() => {
+            expect(onEventReconnect, 'reconnected').to.been.calledWith('B');
+            expect(comB_api2.service.getListenersCount(), 'event handler re-register').to.eq(1);
+        });
+
+        comB_api2.service.invoke();
+
+        await waitFor(() => {
+            expect(onEventEmitterCall, 'invoked event after reconnect').to.have.have.callCount(2);
+        });
+    });
 });
 
 describe('environment-dependencies communication', () => {


### PR DESCRIPTION
This PR fixes a reconnect when the host is not just reloaded, but destroyed and replaced with a new one 