### PR TITLE
fix(com): check if host a cross origin window on dispose

### DIFF
--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -1052,7 +1052,7 @@ function isCrossOriginWindow(host: Target) {
         // cross origin window will throw an error
         // when trying to access the name property
         host.name;
-    } catch (e) {
+    } catch {
         return true;
     }
     return false;

--- a/packages/core/src/com/communication.ts
+++ b/packages/core/src/com/communication.ts
@@ -498,7 +498,7 @@ export class Communication {
             if (host instanceof WsClientHost) {
                 host.subscribers.clear();
             }
-            if (isDisposable(host)) {
+            if (!isCrossOriginWindow(host) && isDisposable(host)) {
                 await host.dispose();
             }
             this.removeMessageHandler(host);
@@ -1046,4 +1046,14 @@ function countValues(set: SetMultiMap<string, unknown>) {
         result[key]++;
     }
     return result;
+}
+function isCrossOriginWindow(host: Target) {
+    try {
+        // cross origin window will throw an error
+        // when trying to access the name property
+        host.name;
+    } catch (e) {
+        return true;
+    }
+    return false;
 }


### PR DESCRIPTION
if we call engine dispose in web env, and one of the environments registered in communication is a cross origin iframe the dispose sequence will fail.
Reason: cannot touch properties on cross origin window proxy objects
Why we did not see it before? never disposed main (editor) env

```
SecurityError: Blocked a frame with origin "http://localhost:4444" from accessing a cross-origin frame.
    at DisposablesGroup.dispose (disposables-group.ts:19:27)
    at async SafeDisposable.dispose (VM6810 chunk-HYGUV2R4.js:525:7)
    at async SafeDisposable.dispose (VM6810 chunk-HYGUV2R4.js:691:7)Caused by: SecurityError: Blocked a frame with origin "http://localhost:4444" from accessing a cross-origin frame.
```